### PR TITLE
🛡️ Sentinel: [HIGH] Fix Email Header Injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-29 - [Fix Email Header Injection]
+**Vulnerability:** The email subject and reply-to headers in the contact form endpoint used raw user input (name, type, email) directly. CRLF injection could allow attackers to manipulate headers.
+**Learning:** Even with XSS sanitization (converting to strings and escaping HTML), CRLF characters (\r, \n) could pass through and inject headers like `Bcc: attacker@example.com` when passing to mail APIs that aren't strictly guarded.
+**Prevention:** Always strip or escape CRLF characters from any user input that will be placed into email headers (Subject, From, Reply-To, etc.) and validate expected formats like emails using strict Regex.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -96,6 +96,20 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
       });
     }
 
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(data.email)) {
+      return new Response(JSON.stringify({ error: 'Ugyldigt email format' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Strip CRLF to prevent Email Header Injection
+    const safeName = data.name.replace(/[\r\n]/g, '');
+    const safeType = data.type.replace(/[\r\n]/g, '');
+    const safeEmail = data.email.replace(/[\r\n]/g, '');
+
     // Hent miljøvariabler fra Cloudflare
     const RESEND_API_KEY = context.env.RESEND_API_KEY;
     const DESTINATION_EMAIL = context.env.QUOTE_DESTINATION_EMAIL || 'info@rendetalje.dk';
@@ -141,9 +155,9 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
       body: JSON.stringify({
         from: `Rendetalje <${FROM_EMAIL}>`,
         to: DESTINATION_EMAIL,
-        subject: `Ny forespørgsel: ${data.type} - ${data.name}`,
+        subject: `Ny forespørgsel: ${safeType} - ${safeName}`,
         html: emailHtml,
-        reply_to: data.email
+        reply_to: safeEmail
       })
     });
 

--- a/src/handlers/quote.ts
+++ b/src/handlers/quote.ts
@@ -90,6 +90,20 @@ export async function handleQuoteRequest(request: Request, env: Env): Promise<Re
       });
     }
 
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(data.email)) {
+      return new Response(JSON.stringify({ error: 'Ugyldigt email format' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Strip CRLF to prevent Email Header Injection
+    const safeName = data.name.replace(/[\r\n]/g, '');
+    const safeType = data.type.replace(/[\r\n]/g, '');
+    const safeEmail = data.email.replace(/[\r\n]/g, '');
+
     const RESEND_API_KEY = env.RESEND_API_KEY;
     const DESTINATION_EMAIL = env.QUOTE_DESTINATION_EMAIL || 'info@rendetalje.dk';
     const FROM_EMAIL = env.FROM_EMAIL || 'info@rendetalje.dk';
@@ -132,9 +146,9 @@ export async function handleQuoteRequest(request: Request, env: Env): Promise<Re
       body: JSON.stringify({
         from: `Rendetalje <${FROM_EMAIL}>`,
         to: DESTINATION_EMAIL,
-        subject: `Ny forespørgsel: ${data.type} - ${data.name}`,
+        subject: `Ny forespørgsel: ${safeType} - ${safeName}`,
         html: emailHtml,
-        reply_to: data.email
+        reply_to: safeEmail
       })
     });
 


### PR DESCRIPTION
Fixed a high-priority Email Header Injection vulnerability in the contact endpoints.

🚨 Severity: HIGH
💡 Vulnerability: CRLF injection allows attackers to manipulate headers like Reply-To by embedding newlines in input fields (name, type, email).
🎯 Impact: Attackers could inject arbitrary headers (e.g., `Bcc: attacker@domain.com`) to intercept quotes or spoof responses.
🔧 Fix: Added Regex validation for email addresses and stripped `\r` and `\n` from name and type fields before utilizing them in headers.
✅ Verification: Ensure tests pass. Run `pnpm build` to confirm no build issues. Checked typescript compilation using node manually.

---
*PR created automatically by Jules for task [2749834923357920318](https://jules.google.com/task/2749834923357920318) started by @JonasAbde*