### PR TITLE
Plausible Analytics + fjern Crawl-delay + CSP update

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    
+    <!-- Analytics -->
+    <script defer data-domain="rendetalje.dk" src="https://plausible.io/js/script.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/_headers
+++ b/public/_headers
@@ -3,5 +3,5 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.resend.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.resend.com https://plausible.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self';
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,9 +4,6 @@ Allow: /
 # Sitemap location
 Sitemap: https://rendetalje.dk/sitemap.xml
 
-# Crawl delay for bots
-Crawl-delay: 1
-
 # Disallow admin areas (if any exist in future)
 # Disallow: /admin/
 # Disallow: /api/


### PR DESCRIPTION
### Ændringer

**1. Plausible Analytics** — `index.html`
- Indsæt `<script defer data-domain="rendetalje.dk" src="https://plausible.io/js/script.js">`
- GDPR-venlig, ingen cookies. Giver data om besøgende, trafikkilder, sider om 24 timer.

**2. CSP opdateret** — `public/_headers`
- `script-src` → tillader `https://plausible.io`
- `connect-src` → tillader `https://plausible.io`

**3. Fjernet `Crawl-delay: 1`** — `public/robots.txt`
- Bremsede Google crawling unødigt

### Næste step efter merge
Cloudflare Pages deployer automatisk fra main. Analytics data begynder at tikke ind indenfor 24 timer.