### PR TITLE
⚡ Bolt: Optimize PriceCalculator re-renders with useMemo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-27 - Replace useEffect derived state with useMemo
+**Learning:** In React components like `PriceCalculator.tsx`, using `useState` and `useEffect` to derive state from props (e.g., calculating an estimate when a range slider changes) causes a double re-render. This blocks the main thread and can make high-frequency events like sliders feel unresponsive.
+**Action:** Replace derived state `useEffect` chains with a single `useMemo` calculation. This computes the derived state synchronously during the initial render pass, improving responsiveness by preventing the redundant second render cycle.

--- a/src/components/contact/PriceCalculator.tsx
+++ b/src/components/contact/PriceCalculator.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import { motion, AnimatePresence } from "motion/react";
 
 interface PriceCalculatorProps {
@@ -45,10 +45,9 @@ export default function PriceCalculator({
   onSizeChange,
   onFrequencyChange,
 }: PriceCalculatorProps) {
-  const [estimate, setEstimate] = useState({ min: 0, max: 0 });
   const sizeNum = parseInt(size) || 0;
 
-  useEffect(() => {
+  const estimate = useMemo(() => {
     const base = basePrices[type] || 400;
     const perSqm = perSqmRates[type] || 20;
     const sizeCost = sizeNum * perSqm;
@@ -56,10 +55,10 @@ export default function PriceCalculator({
     const discount = subtotal * (frequencyDiscounts[frequency] || 0);
     const total = subtotal - discount;
     
-    setEstimate({
+    return {
       min: Math.round(total * 0.85),
       max: Math.round(total * 1.15),
-    });
+    };
   }, [type, sizeNum, frequency]);
 
   return (


### PR DESCRIPTION
💡 **What:** Replaced the `useState` and `useEffect` chain that derived the `estimate` state with a single `useMemo` hook in `PriceCalculator.tsx`.

🎯 **Why:** The previous approach used derived state (`useEffect` updating a `useState` variable based on props). This is a React anti-pattern that triggers a second re-render every time the inputs (like the slider size) change. During high-frequency events like dragging a range slider, this double-rendering blocks the main thread and can make the UI feel sluggish. Using `useMemo` evaluates the calculation synchronously during the initial render pass, avoiding the second redundant render.

📊 **Impact:** Reduces component re-renders by 50% during interactions, significantly improving slider responsiveness.

🔬 **Measurement:** Verify the improvement by dragging the range slider for the size in the Contact/Price Calculator component. The slider should feel more responsive.

(Includes a new journal entry in `.jules/bolt.md` documenting this React derived state pattern optimization.)

---
*PR created automatically by Jules for task [931459586062307995](https://jules.google.com/task/931459586062307995) started by @JonasAbde*