### PR TITLE
🎨 Palette: Form Label Accessibility Improvement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-02 - Form Labels Accessibility
+**Learning:** Isolated form fields in complex step-based forms (like MultiStepForm) often lack explicit `id` and `htmlFor` binding, preventing screen readers from associating the label with the input and preventing users from clicking labels to focus fields.
+**Action:** Always ensure standard form `<label>` and `<input>`/`<textarea>` pairs use explicit `htmlFor` and `id` attributes when they are not nested.

--- a/src/components/contact/MultiStepForm.tsx
+++ b/src/components/contact/MultiStepForm.tsx
@@ -155,10 +155,11 @@ export default function MultiStepForm({
 
               {/* Additional fields */}
               <div className="space-y-2">
-                <label className="block text-sm font-medium text-slate-700">
+                <label htmlFor="date" className="block text-sm font-medium text-slate-700">
                   Ønsket dato / tidsramme
                 </label>
                 <input
+                  id="date"
                   type="text"
                   value={formData.date}
                   onChange={(e) => updateField("date", e.target.value)}
@@ -168,10 +169,11 @@ export default function MultiStepForm({
               </div>
 
               <div className="space-y-2">
-                <label className="block text-sm font-medium text-slate-700">
+                <label htmlFor="description" className="block text-sm font-medium text-slate-700">
                   Kort beskrivelse af opgaven
                 </label>
                 <textarea
+                  id="description"
                   value={formData.description}
                   onChange={(e) => updateField("description", e.target.value)}
                   rows={4}
@@ -218,10 +220,11 @@ export default function MultiStepForm({
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label htmlFor="name" className="block text-sm font-medium text-slate-700">
                     Navn *
                   </label>
                   <input
+                    id="name"
                     type="text"
                     value={formData.name}
                     onChange={(e) => updateField("name", e.target.value)}
@@ -230,10 +233,11 @@ export default function MultiStepForm({
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label htmlFor="phone" className="block text-sm font-medium text-slate-700">
                     Telefon *
                   </label>
                   <input
+                    id="phone"
                     type="tel"
                     value={formData.phone}
                     onChange={(e) => updateField("phone", e.target.value)}
@@ -244,10 +248,11 @@ export default function MultiStepForm({
               </div>
 
               <div className="space-y-2">
-                <label className="block text-sm font-medium text-slate-700">
+                <label htmlFor="email" className="block text-sm font-medium text-slate-700">
                   Email *
                 </label>
                 <input
+                  id="email"
                   type="email"
                   value={formData.email}
                   onChange={(e) => updateField("email", e.target.value)}
@@ -258,10 +263,11 @@ export default function MultiStepForm({
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label htmlFor="address" className="block text-sm font-medium text-slate-700">
                     Adresse (valgfri, hjælper med pris)
                   </label>
                   <input
+                    id="address"
                     type="text"
                     value={formData.address}
                     onChange={(e) => updateField("address", e.target.value)}
@@ -269,10 +275,11 @@ export default function MultiStepForm({
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label htmlFor="city" className="block text-sm font-medium text-slate-700">
                     Postnr. / By
                   </label>
                   <input
+                    id="city"
                     type="text"
                     value={formData.city}
                     onChange={(e) => updateField("city", e.target.value)}
@@ -283,8 +290,8 @@ export default function MultiStepForm({
 
               {/* GDPR checkbox */}
               <div className="mb-6">
-                <label className="flex items-start gap-3 cursor-pointer">
-                  <input type="checkbox" checked={gdprAccepted} onChange={(e) => setGdprAccepted(e.target.checked)} required className="mt-1 w-4 h-4 rounded border-slate-300 text-green-600 focus:ring-green-500" />
+                <label htmlFor="gdpr" className="flex items-start gap-3 cursor-pointer">
+                  <input id="gdpr" type="checkbox" checked={gdprAccepted} onChange={(e) => setGdprAccepted(e.target.checked)} required className="mt-1 w-4 h-4 rounded border-slate-300 text-green-600 focus:ring-green-500" />
                   <span className="text-sm text-slate-600">Jeg accepterer at Rendetalje må kontakte mig omkring mit tilbud. Læs vores <Link to="/privatlivspolitik" className="text-green-600 hover:underline">privatlivspolitik</Link>.</span>
                 </label>
               </div>

--- a/src/components/contact/PriceCalculator.tsx
+++ b/src/components/contact/PriceCalculator.tsx
@@ -66,11 +66,12 @@ export default function PriceCalculator({
     <div className="space-y-6">
       {/* Size input */}
       <div className="space-y-3">
-        <label className="block text-sm font-medium text-slate-700">
+        <label htmlFor="size" className="block text-sm font-medium text-slate-700">
           Ca. størrelse (m²)
         </label>
         <div className="flex items-center gap-4">
           <input
+            id="size_range"
             type="range"
             min="0"
             max="300"
@@ -80,6 +81,7 @@ export default function PriceCalculator({
           />
           <div className="w-24">
             <input
+              id="size"
               type="number"
               value={size}
               onChange={(e) => onSizeChange(e.target.value)}


### PR DESCRIPTION
🎨 Palette: [UX improvement] - Form label accessibility

💡 What: Added explicit `htmlFor` attributes to `<label>` elements and matching `id` attributes to their corresponding `<input>` and `<textarea>` elements across `MultiStepForm.tsx` and `PriceCalculator.tsx`.

🎯 Why: In complex forms where labels aren't strictly wrapping inputs, failing to bind them means screen readers cannot properly announce the field's purpose, and users cannot click the label text to focus the field. This change resolves those issues.

📸 Before/After: Visuals remain unchanged, but programmatic accessibility and click targets are improved.

♿ Accessibility: Ensures that form fields have an accessible name calculated from the label, and clicking the label focuses the field. Also updated the `.Jules/palette.md` journal with this pattern learning.

---
*PR created automatically by Jules for task [2599987598083869663](https://jules.google.com/task/2599987598083869663) started by @JonasAbde*