### PR TITLE
🎨 Palette: Add proper label associations in forms

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-04 - Explicit ARIA Radiogroups for Custom Controls
 **Learning:** Custom input groups acting as radio buttons (like button-based selection arrays) are not inherently connected by standard HTML linkage (`htmlFor`). They require explicit ARIA grouping using `role="radiogroup"` and `aria-labelledby` on the container, and `role="radio"` and `aria-checked` on the items to ensure screen reader users understand the relationship and state of the options.
 **Action:** Always apply `role="radiogroup"`, `aria-labelledby`, `role="radio"`, and `aria-checked` to custom button-based selection options instead of relying on standard inputs, and pair this with clear `focus-visible` styling for keyboard navigators.
+
+## 2024-05-03 - Complex Form Labelling
+**Learning:** In step-based or dynamic forms like `MultiStepForm` and `PriceCalculator`, form elements and `<label>` tags are sometimes visually separated or functionally wrapped, causing developers to forget `htmlFor` and `id` linking. Furthermore, custom components acting like radio buttons (e.g. Frequency Selector) need explicitly defined `role="radiogroup"` on the wrapper and `role="radio"`, `aria-checked` on the buttons to remain accessible to screen readers, instead of standard `htmlFor` label linkage.
+**Action:** When adding new form fields or complex multi-step wizards, always ensure standard `<input>`/`<textarea>` elements use paired `htmlFor`/`id` combinations. For custom input groups (like button-based selection arrays), explicitly apply ARIA grouping (`radiogroup`) and states (`aria-checked`).

--- a/src/components/contact/MultiStepForm.tsx
+++ b/src/components/contact/MultiStepForm.tsx
@@ -158,10 +158,11 @@ export default function MultiStepForm({
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label htmlFor="name" className="block text-sm font-medium text-slate-700">
                     Navn *
                   </label>
                   <input
+                    id="name"
                     type="text"
                     value={formData.name}
                     onChange={(e) => updateField("name", e.target.value)}
@@ -170,10 +171,11 @@ export default function MultiStepForm({
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label htmlFor="phone" className="block text-sm font-medium text-slate-700">
                     Telefon *
                   </label>
                   <input
+                    id="phone"
                     type="tel"
                     value={formData.phone}
                     onChange={(e) => updateField("phone", e.target.value)}
@@ -184,10 +186,11 @@ export default function MultiStepForm({
               </div>
 
               <div className="space-y-2">
-                <label className="block text-sm font-medium text-slate-700">
+                <label htmlFor="email" className="block text-sm font-medium text-slate-700">
                   Email *
                 </label>
                 <input
+                  id="email"
                   type="email"
                   value={formData.email}
                   onChange={(e) => updateField("email", e.target.value)}
@@ -198,10 +201,11 @@ export default function MultiStepForm({
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label htmlFor="address" className="block text-sm font-medium text-slate-700">
                     Adresse / Område (valgfri)
                   </label>
                   <input
+                    id="address"
                     type="text"
                     value={formData.address}
                     onChange={(e) => updateField("address", e.target.value)}
@@ -210,10 +214,11 @@ export default function MultiStepForm({
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label htmlFor="city" className="block text-sm font-medium text-slate-700">
                     Postnr. / By
                   </label>
                   <input
+                    id="city"
                     type="text"
                     value={formData.city}
                     onChange={(e) => updateField("city", e.target.value)}
@@ -224,10 +229,11 @@ export default function MultiStepForm({
               </div>
 
               <div className="space-y-2">
-                <label className="block text-sm font-medium text-slate-700">
+                <label htmlFor="description" className="block text-sm font-medium text-slate-700">
                   Kort beskrivelse af opgaven (valgfri)
                 </label>
                 <textarea
+                  id="description"
                   value={formData.description}
                   onChange={(e) => updateField("description", e.target.value)}
                   rows={3}
@@ -237,10 +243,11 @@ export default function MultiStepForm({
               </div>
 
               <div className="space-y-2">
-                <label className="block text-sm font-medium text-slate-700">
+                <label htmlFor="date" className="block text-sm font-medium text-slate-700">
                   Ønsket tidspunkt (valgfri)
                 </label>
                 <input
+                  id="date"
                   type="text"
                   value={formData.date}
                   onChange={(e) => updateField("date", e.target.value)}
@@ -250,9 +257,9 @@ export default function MultiStepForm({
               </div>
 
               {/* GDPR checkbox */}
-              <div className="mb-4">
-                <label className="flex items-start gap-3 cursor-pointer">
-                  <input type="checkbox" checked={gdprAccepted} onChange={(e) => setGdprAccepted(e.target.checked)} required className="mt-1 w-4 h-4 rounded border-slate-300 text-green-600 focus:ring-green-500" />
+              <div className="mb-6">
+                <label htmlFor="gdpr" className="flex items-start gap-3 cursor-pointer">
+                  <input id="gdpr" type="checkbox" checked={gdprAccepted} onChange={(e) => setGdprAccepted(e.target.checked)} required className="mt-1 w-4 h-4 rounded border-slate-300 text-green-600 focus:ring-green-500" />
                   <span className="text-sm text-slate-600">Jeg accepterer at Rendetalje må kontakte mig omkring mit tilbud. Læs vores <Link to="/privatlivspolitik" className="text-green-600 hover:underline">privatlivspolitik</Link>.</span>
                 </label>
               </div>

--- a/src/components/contact/PriceCalculator.tsx
+++ b/src/components/contact/PriceCalculator.tsx
@@ -82,11 +82,12 @@ export default function PriceCalculator({
     <div className="space-y-6">
       {/* Size input */}
       <div className="space-y-3">
-        <label className="block text-sm font-medium text-slate-700">
+        <label htmlFor="size" className="block text-sm font-medium text-slate-700">
           Ca. størrelse (m²)
         </label>
         <div className="flex items-center gap-4">
           <input
+            id="size"
             type="range"
             min="0"
             max="300"
@@ -111,14 +112,16 @@ export default function PriceCalculator({
 
       {/* Frequency selector */}
       <div className="space-y-3">
-        <label className="block text-sm font-medium text-slate-700">
+        <label id="frequency-label" className="block text-sm font-medium text-slate-700">
           Ønsket frekvens
         </label>
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-3 gap-3" role="radiogroup" aria-labelledby="frequency-label">
           {Object.entries(frequencyLabels).map(([value, label]) => (
             <button
               key={value}
               type="button"
+              role="radio"
+              aria-checked={frequency === value}
               onClick={() => onFrequencyChange(value)}
               className={`py-3 px-4 rounded-xl border-2 text-sm font-medium transition-all ${
                 frequency === value


### PR DESCRIPTION
💡 What: Added `htmlFor` and `id` linking to all unlinked forms, and changed `MultiStepForm` and `PriceCalculator` inputs and tags to use correct ARIA grouping conventions for radiogroups.
🎯 Why: Forms with inputs missing associated labels or incorrect accessible patterns make it difficult for screen reader users to understand what the input represents, and clicking the label doesn't focus the inputs for mouse/touch users.
♿ Accessibility: Ensures that inputs and buttons have explicit context, which makes form filling completely accessible.

---
*PR created automatically by Jules for task [893100422254662658](https://jules.google.com/task/893100422254662658) started by @JonasAbde*