### PR TITLE
⚡ Bolt: memoize estimate in PriceCalculator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Prevent Redundant Computations with useMemo
+**Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
+**Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.

--- a/src/components/contact/PriceCalculator.tsx
+++ b/src/components/contact/PriceCalculator.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { trackEvent } from "@/lib/analytics";
 
@@ -46,9 +46,22 @@ export default function PriceCalculator({
   onSizeChange,
   onFrequencyChange,
 }: PriceCalculatorProps) {
-  const [estimate, setEstimate] = useState({ min: 0, max: 0 });
   const sizeNum = parseInt(size) || 0;
   const hasTracked = useRef(false);
+
+  const estimate = useMemo(() => {
+    const base = basePrices[type] || 400;
+    const perSqm = perSqmRates[type] || 20;
+    const sizeCost = sizeNum * perSqm;
+    const subtotal = base + sizeCost;
+    const discount = subtotal * (frequencyDiscounts[frequency] || 0);
+    const total = subtotal - discount;
+
+    return {
+      min: Math.round(total * 0.85),
+      max: Math.round(total * 1.15),
+    };
+  }, [type, sizeNum, frequency]);
 
   // Track first complete calculator interaction
   useEffect(() => {
@@ -64,20 +77,6 @@ export default function PriceCalculator({
       });
     }
   }, [type, sizeNum, frequency, estimate.min, estimate.max]);
-
-  useEffect(() => {
-    const base = basePrices[type] || 400;
-    const perSqm = perSqmRates[type] || 20;
-    const sizeCost = sizeNum * perSqm;
-    const subtotal = base + sizeCost;
-    const discount = subtotal * (frequencyDiscounts[frequency] || 0);
-    const total = subtotal - discount;
-    
-    setEstimate({
-      min: Math.round(total * 0.85),
-      max: Math.round(total * 1.15),
-    });
-  }, [type, sizeNum, frequency]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
💡 What: The optimization replaces an effect that immediately triggers state updates with a synchronized memoized calculation for the `estimate`.
🎯 Why: It solves an immediate double-render whenever the component properties change, caused by setting state inside a `useEffect` after initial rendering.
📊 Impact: Expected performance improvement eliminates 1 completely unnecessary render cycle per property change.
🔬 Measurement: To verify the improvement, measure the render cycles of `PriceCalculator` using React DevTools when interacting with size or frequency inputs; it should render once per interaction instead of twice.

---
*PR created automatically by Jules for task [7711062509804246886](https://jules.google.com/task/7711062509804246886) started by @JonasAbde*