### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS Type Confusion and Header Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The application was using `Math.random()` to generate the random portion of booking references (e.g., `REN-260502-123`). `Math.random()` is not cryptographically secure and produces predictable outputs.
 **Learning:** For any sensitive or outward-facing identifiers that require randomness, we must use the Web Crypto API (`crypto.getRandomValues()`) instead of `Math.random()`. `Math.random()` is acceptable for non-security contexts like animations (e.g., confetti particles).
 **Prevention:** Always use `crypto.getRandomValues()` with typed arrays (like `Uint32Array`) when generating random identifiers, tokens, or references.
+
+## 2024-05-04 - [Fix XSS Type Confusion and Email Header Injection]
+**Vulnerability:** Type Confusion XSS in API sanitization (due to missing recursive sanitization) and potential Email Header Injection (due to CRLF injection in email subjects).
+**Learning:** Arrays and nested objects can bypass top-level string replacements and still invoke `toString()` during template interpolation resulting in XSS. User inputs mapped directly to email headers need explicit `\r\n` removal.
+**Prevention:** Always implement recursive object traversal for sanitization and strip CRLF inputs from headers explicitly.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -48,19 +48,28 @@ type Env = {
   FROM_EMAIL?: string;
 };
 
-// Sanitize all object values
-function sanitizeObject(obj: Record<string, unknown>): QuoteData {
-  const sanitized: QuoteData = {};
-  for (const key in obj) {
-    const value = obj[key];
-    if (typeof value === 'string') {
-      sanitized[key] = sanitizeInput(value) as string;
-    } else {
-      sanitized[key] = value;
+// Sanitize all object values recursively
+function sanitizeValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return sanitizeInput(value);
+  } else if (Array.isArray(value)) {
+    return value.map(sanitizeValue);
+  } else if (value !== null && typeof value === 'object') {
+    const sanitized: Record<string, unknown> = {};
+    for (const key in value as Record<string, unknown>) {
+      sanitized[key] = sanitizeValue((value as Record<string, unknown>)[key]);
     }
+    return sanitized;
   }
-  return sanitized;
+  return value;
 }
+
+function sanitizeObject(obj: Record<string, unknown>): QuoteData {
+  return sanitizeValue(obj) as QuoteData;
+}
+
+// Simple email validation regex
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 // Main handler - handles all methods
 export async function onRequest(context: EventContext<Env, string, unknown>): Promise<Response> {
@@ -95,6 +104,17 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       });
     }
+
+    if (!EMAIL_REGEX.test(data.email)) {
+      return new Response(JSON.stringify({ error: 'Invalid email format' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Prevent header injection by removing CRLF from inputs used in subject safely
+    const safeName = typeof data.name === 'string' ? data.name.replace(/[\r\n]/g, '') : '';
+    const safeType = typeof data.type === 'string' ? data.type.replace(/[\r\n]/g, '') : '';
 
     // Hent miljøvariabler fra Cloudflare
     const RESEND_API_KEY = context.env.RESEND_API_KEY;
@@ -141,7 +161,7 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
       body: JSON.stringify({
         from: `Rendetalje <${FROM_EMAIL}>`,
         to: DESTINATION_EMAIL,
-        subject: `Ny forespørgsel: ${data.type} - ${data.name}`,
+        subject: `Ny forespørgsel: ${safeType} - ${safeName}`,
         html: emailHtml,
         reply_to: data.email
       })


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unsanitized nested arrays and objects bypassed the top-level string replacements and led to Type Confusion XSS. Additionally, raw string values parsed from the form (`data.type`, `data.name`) mapped to email subject headers could introduce potential CRLF (`\r\n`) injection attacks.
🎯 **Impact:** XSS via Cloudflare workers rendering email forms alongside unintended header/SMTP command manipulation by attackers via carriage returns.
🔧 **Fix:** 
- Recursively validate form input objects ensuring fields resolve reliably.
- Validated email fields specifically via regex. 
- Prevented potential email header injection by aggressively stripping `\r\n` from any input directly applied to the Resend API headers.
✅ **Verification:** Verified via strict custom `tsc` linting command and standard production building.

---
*PR created automatically by Jules for task [17851458933765919056](https://jules.google.com/task/17851458933765919056) started by @JonasAbde*