### PR TITLE
🎨 Palette: Add explicit ARIA radiogroup for service selection

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-04 - Explicit ARIA Radiogroups for Custom Controls
+**Learning:** Custom input groups acting as radio buttons (like button-based selection arrays) are not inherently connected by standard HTML linkage (`htmlFor`). They require explicit ARIA grouping using `role="radiogroup"` and `aria-labelledby` on the container, and `role="radio"` and `aria-checked` on the items to ensure screen reader users understand the relationship and state of the options.
+**Action:** Always apply `role="radiogroup"`, `aria-labelledby`, `role="radio"`, and `aria-checked` to custom button-based selection options instead of relying on standard inputs, and pair this with clear `focus-visible` styling for keyboard navigators.

--- a/src/components/contact/ServiceSelector.tsx
+++ b/src/components/contact/ServiceSelector.tsx
@@ -52,11 +52,11 @@ const services = [
 export default function ServiceSelector({ selected, onSelect }: ServiceSelectorProps) {
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-slate-900 mb-6">
+      <h3 id="service-selector-label" className="text-lg font-semibold text-slate-900 mb-6">
         Hvilken type rengøring har du brug for?
       </h3>
       
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div role="radiogroup" aria-labelledby="service-selector-label" className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {services.map((service, index) => {
           const Icon = service.icon;
           const isSelected = selected === service.id;
@@ -65,8 +65,10 @@ export default function ServiceSelector({ selected, onSelect }: ServiceSelectorP
             <motion.button
               key={service.id}
               type="button"
+              role="radio"
+              aria-checked={isSelected}
               onClick={() => onSelect(service.id)}
-              className={`relative p-6 rounded-2xl border-2 text-left transition-all duration-300 ${
+              className={`relative p-6 rounded-2xl border-2 text-left transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500 ${
                 isSelected ? service.activeColor : service.color
               }`}
               initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
The ServiceSelector component's selection options act as a radio group. Because it uses `<motion.button>` elements instead of standard HTML `<input type="radio">` and `<label>` pairs, standard semantic linkage is missing for screen readers. 

This PR implements explicit ARIA groupings:
- Adds an `id` to the heading.
- Adds `role="radiogroup"` and `aria-labelledby` to the wrapper div.
- Adds `role="radio"` and `aria-checked` attributes to each button.
- Adds explicit `focus-visible` Tailwind classes for better visual keyboard navigation feedback.

Also updates the Palette journal with this critical learning.

---
*PR created automatically by Jules for task [5756628355945124332](https://jules.google.com/task/5756628355945124332) started by @JonasAbde*