### PR TITLE
🛡️ Sentinel: [HIGH] Add in-memory rate limiting to API endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Type Confusion XSS in API sanitization (due to missing recursive sanitization) and potential Email Header Injection (due to CRLF injection in email subjects).
 **Learning:** Arrays and nested objects can bypass top-level string replacements and still invoke `toString()` during template interpolation resulting in XSS. User inputs mapped directly to email headers need explicit `\r\n` removal.
 **Prevention:** Always implement recursive object traversal for sanitization and strip CRLF inputs from headers explicitly.
+
+## 2024-05-06 - [Add In-Memory Rate Limiting to Cloudflare Pages Functions]
+**Vulnerability:** Missing rate limiting on sensitive API endpoints (like quote generation) can lead to abuse, spam, and DoS attacks.
+**Learning:** Cloudflare Workers isolates are generally short-lived, but they can persist state between requests. Simple in-memory maps are effective for basic rate limiting across the same isolate instance. However, without a size cap, these maps could cause memory leaks if left unchecked. Rate limiting checks should also always happen *after* handling CORS `OPTIONS` preflight requests so preflights don't accidentally consume limit quotas.
+**Prevention:** Implement Map-based memory structures with size limit checks (`if (map.size > MAX) map.clear();`) for simple per-isolate IP throttling. Apply this consistently to endpoints handling form submissions or API actions.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -71,6 +71,18 @@ function sanitizeObject(obj: Record<string, unknown>): QuoteData {
 // Simple email validation regex
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+// In-memory rate limiter configuration
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const MAX_REQUESTS_PER_WINDOW = 5;
+const MAX_MAP_SIZE = 1000; // Prevent memory leak
+
+interface RateLimitInfo {
+  count: number;
+  resetTime: number;
+}
+
+const rateLimitMap = new Map<string, RateLimitInfo>();
+
 // Main handler - handles all methods
 export async function onRequest(context: EventContext<Env, string, unknown>): Promise<Response> {
   const request = context.request;
@@ -83,6 +95,37 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
       status: 204,
       headers: corsHeaders,
     });
+  }
+
+  // Rate Limiting (apply after OPTIONS preflight)
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const now = Date.now();
+
+  // Cleanup if the map gets too big
+  if (rateLimitMap.size > MAX_MAP_SIZE) {
+    rateLimitMap.clear();
+  }
+
+  let rateInfo = rateLimitMap.get(clientIp);
+
+  if (!rateInfo || now > rateInfo.resetTime) {
+    // New window
+    rateInfo = { count: 1, resetTime: now + RATE_LIMIT_WINDOW_MS };
+    rateLimitMap.set(clientIp, rateInfo);
+  } else {
+    // Existing window
+    rateInfo.count += 1;
+    if (rateInfo.count > MAX_REQUESTS_PER_WINDOW) {
+      return new Response(JSON.stringify({ error: 'Too many requests, please try again later.' }), {
+        status: 429,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+          'Retry-After': String(Math.ceil((rateInfo.resetTime - now) / 1000))
+        }
+      });
+    }
+    rateLimitMap.set(clientIp, rateInfo);
   }
 
   // Only allow POST


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Missing rate limiting on the sensitive quote generation endpoint allows potential abuse, spam, and simple denial-of-service (DoS) attacks.
🎯 **Impact:** An attacker could automate submissions, exhausting API quotas (like Resend emails) and degrading performance for real users.
🔧 **Fix:** Implemented an in-memory Map-based rate limiter tracking request counts via `CF-Connecting-IP`. The system allows 5 requests per minute, applying checks post-CORS preflight and utilizing a size limit cache cleanup (`MAX_MAP_SIZE`) to prevent potential memory leaks in Cloudflare Workers isolates.
✅ **Verification:** A 429 status response is correctly returned if the window limit is exceeded. 

(Note: Updated Sentinel journal with related learnings).

---
*PR created automatically by Jules for task [13855028709507009992](https://jules.google.com/task/13855028709507009992) started by @JonasAbde*