### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on `/api/quote`

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Type Confusion XSS in API sanitization (due to missing recursive sanitization) and potential Email Header Injection (due to CRLF injection in email subjects).
 **Learning:** Arrays and nested objects can bypass top-level string replacements and still invoke `toString()` during template interpolation resulting in XSS. User inputs mapped directly to email headers need explicit `\r\n` removal.
 **Prevention:** Always implement recursive object traversal for sanitization and strip CRLF inputs from headers explicitly.
+
+## 2024-05-07 - Add Rate Limiting to Quote API
+**Vulnerability:** Missing rate limiting on the `/api/quote` email endpoint, which could allow an attacker to exhaust the Resend API quota.
+**Learning:** Cloudflare Pages Functions run in isolates. In-memory rate limiting using a `Map` works per-isolate but needs a size limit (e.g. > 1000 entries) to avoid memory leaks. Also, `CF-Connecting-IP` isn't always present in local dev environments, requiring conditionally skipped limits to prevent blocking local development.
+**Prevention:** Add an in-memory rate limiter with a maximum size check and ensure `CF-Connecting-IP` is present before tracking limits.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -71,6 +71,11 @@ function sanitizeObject(obj: Record<string, unknown>): QuoteData {
 // Simple email validation regex
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+// In-memory rate limiting (per isolate)
+const rateLimitMap = new Map<string, { count: number; timestamp: number }>();
+const RATE_LIMIT_WINDOW = 60000; // 1 minute
+const MAX_REQUESTS = 5; // 5 requests per minute
+
 // Main handler - handles all methods
 export async function onRequest(context: EventContext<Env, string, unknown>): Promise<Response> {
   const request = context.request;
@@ -83,6 +88,25 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
       status: 204,
       headers: corsHeaders,
     });
+  }
+
+  // Rate Limiting Logic
+  const ip = request.headers.get('CF-Connecting-IP');
+  if (ip) {
+    if (rateLimitMap.size > 1000) rateLimitMap.clear(); // Prevent memory leak in isolate
+    const now = Date.now();
+    const limit = rateLimitMap.get(ip);
+    if (limit && now - limit.timestamp < RATE_LIMIT_WINDOW) {
+      if (limit.count >= MAX_REQUESTS) {
+        return new Response(JSON.stringify({ error: 'Too many requests' }), {
+          status: 429,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+      limit.count++;
+    } else {
+      rateLimitMap.set(ip, { count: 1, timestamp: now });
+    }
   }
 
   // Only allow POST


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/api/quote` endpoint lacked rate limiting, allowing a malicious actor to potentially exhaust the application's Resend API quota or degrade performance.
🎯 Impact: Denial of Service via quota exhaustion, potential increased costs.
🔧 Fix: Implemented an in-memory sliding-window rate limiter per isolate via a JS `Map`, keyed by `CF-Connecting-IP`. The map is automatically cleared if size exceeds 1000 to prevent long-lived isolate memory leaks.
✅ Verification: Rate limit blocks requests exceeding 5 per minute and returns a 429 status. Tests pass successfully.

---
*PR created automatically by Jules for task [14462558773246528210](https://jules.google.com/task/14462558773246528210) started by @JonasAbde*