### PR TITLE
⚡ Bolt: Extract static image mapping outside of loop

### DIFF
--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -27,6 +27,15 @@ const serviceTypes = [
   { id: "andet", label: "Andet" },
 ];
 
+// ⚡ Bolt: Extract static image mapping outside of the component.
+// This prevents the object from being re-allocated on every iteration in the .map() loop, saving unnecessary memory allocation during render.
+const SERVICE_IMAGES_MAP: Record<string, string> = {
+  "fast-rengoering": "/images/service-fast.webp",
+  "flytterengoering": "/images/service-flyt.webp",
+  "hovedrengoering": "/images/service-hoved.webp",
+  "erhvervsrengoering": "/images/service-erhverv.webp",
+};
+
 function QuickQuoteForm() {
   const [formState, setFormState] = useState<FormState>("idle");
   const [serviceType, setServiceType] = useState("");
@@ -311,13 +320,7 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {coreServices.map((service, i) => {
               const Icon = service.icon;
-              const imgMap: Record<string, string> = {
-                "fast-rengoering": "/images/service-fast.webp",
-                "flytterengoering": "/images/service-flyt.webp",
-                "hovedrengoering": "/images/service-hoved.webp",
-                "erhvervsrengoering": "/images/service-erhverv.webp",
-              };
-              const imgSrc = imgMap[service.id];
+              const imgSrc = SERVICE_IMAGES_MAP[service.id];
               return (
                 <Link
                   key={i}


### PR DESCRIPTION
💡 What: Moved the `imgMap` static object out of the `.map()` loop in the `Home.tsx` component into a module-scoped constant (`SERVICE_IMAGES_MAP`).
🎯 Why: Prevents unnecessary memory allocation and garbage collection overhead caused by redefining a static object on every single iteration of the loop during every render cycle of the `Home` component.
📊 Impact: Minor memory savings and a fractional decrease in render time overhead for the `Home` component. Eliminates O(N) object allocations per render.
🔬 Measurement: Verified the code behaves identically to before and the object is no longer defined within the render method scope.

---
*PR created automatically by Jules for task [12671296187771729098](https://jules.google.com/task/12671296187771729098) started by @JonasAbde*