### PR TITLE
🛡️ Sentinel: [HIGH] Fix Missing Rate Limiting on Quote API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Type Confusion XSS in API sanitization (due to missing recursive sanitization) and potential Email Header Injection (due to CRLF injection in email subjects).
 **Learning:** Arrays and nested objects can bypass top-level string replacements and still invoke `toString()` during template interpolation resulting in XSS. User inputs mapped directly to email headers need explicit `\r\n` removal.
 **Prevention:** Always implement recursive object traversal for sanitization and strip CRLF inputs from headers explicitly.
+
+## 2024-05-08 - [In-Memory Rate Limiting on Cloudflare Workers]
+**Vulnerability:** Missing rate limiting on the `/api/quote` email endpoint allowed unrestricted POST requests, opening the possibility for email spam/abuse and potential resource exhaustion.
+**Learning:** In Cloudflare Workers/Pages Functions, the client IP can be identified via the `CF-Connecting-IP` header. In-memory `Map` objects are suitable for basic rate-limiting within an isolate but preflight `OPTIONS` requests should not be counted. Since local environments may omit this header, bypassing the check locally avoids globally sharing the limit. Isolates can be long-lived, so maps must incorporate a cleanup mechanism (like clearing at >1000 entries) to prevent memory leaks.
+**Prevention:** Always implement rate limiting on unauthenticated POST endpoints using `CF-Connecting-IP`. Check limits after CORS preflight, skip when IP is absent (for local dev), and bound the `Map` size to prevent memory leaks.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -71,6 +71,11 @@ function sanitizeObject(obj: Record<string, unknown>): QuoteData {
 // Simple email validation regex
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+// Basic in-memory rate limiting map
+const rateLimitMap = new Map<string, { count: number, timestamp: number }>();
+const RATE_LIMIT_MAX_REQUESTS = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+
 // Main handler - handles all methods
 export async function onRequest(context: EventContext<Env, string, unknown>): Promise<Response> {
   const request = context.request;
@@ -83,6 +88,29 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
       status: 204,
       headers: corsHeaders,
     });
+  }
+
+  // Rate Limiting (Evaluate after OPTIONS to avoid counting preflights)
+  const clientIP = request.headers.get('CF-Connecting-IP');
+  if (clientIP) {
+    const now = Date.now();
+    const limitData = rateLimitMap.get(clientIP);
+
+    if (limitData && now - limitData.timestamp < RATE_LIMIT_WINDOW_MS) {
+      if (limitData.count >= RATE_LIMIT_MAX_REQUESTS) {
+        return new Response(JSON.stringify({ error: 'Too many requests, please try again later.' }), {
+          status: 429,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
+      limitData.count += 1;
+    } else {
+      // Prevent memory leaks in long-lived isolates by clearing if it grows too large
+      if (rateLimitMap.size > 1000) {
+        rateLimitMap.clear();
+      }
+      rateLimitMap.set(clientIP, { count: 1, timestamp: now });
+    }
   }
 
   // Only allow POST


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/api/quote` endpoint (which sends emails via the Resend API) had no rate limiting, allowing unauthenticated attackers to flood the endpoint. This could result in email spam, abuse, and exhaustion of Resend API quotas or costs.
🎯 Impact: An attacker could rapidly trigger the endpoint, consuming API credits and causing denial of service on legitimate email deliveries.
🔧 Fix: Implemented an in-memory `Map` within the Cloudflare Pages Function isolate to limit requests by `CF-Connecting-IP` (5 requests per minute). Evaluated after CORS `OPTIONS` preflight, properly handles local dev environments lacking the IP header, and includes a cleanup mechanism (>1000 entries) to prevent isolate memory leaks.
✅ Verification: Tested locally via `tsc` verification of the isolated function file and full production build verification via `pnpm build`. Added the entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10855931211878409139](https://jules.google.com/task/10855931211878409139) started by @JonasAbde*