### PR TITLE
🎨 Palette: Add accessibility attributes and Escape key support to mobile menu

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-12 - Mobile Menu Accessibility State
+**Learning:** Mobile menus often rely solely on visual cues or DOM presence. Screen readers need explicit state communication via `aria-expanded` and semantic linkage via `aria-controls` to understand that a button toggles a region. Additionally, keyboard navigation users require the `Escape` key to easily dismiss the menu.
+**Action:** Always pair mobile menu toggle buttons with `aria-expanded` reflecting state, `aria-controls` pointing to the menu container's ID, and an `Escape` key listener on the window/document to ensure keyboard accessibility when adding custom mobile navigation patterns.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -21,6 +21,22 @@ export default function Header() {
     if (path === "/" && location.pathname !== "/") return false;
     return location.pathname.startsWith(path) && path !== "/";
   };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    if (isMobileMenuOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isMobileMenuOpen]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-100 bg-white/80 backdrop-blur-md">
@@ -69,6 +85,8 @@ export default function Header() {
         <button
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -77,7 +95,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
This PR adds important accessibility improvements to the mobile menu in `src/components/layout/Header.tsx`:

- Adds `aria-expanded` to the toggle button, dynamically reflecting the open/closed state for screen readers.
- Adds `aria-controls="mobile-menu"` to semantically link the button to the dropdown.
- Adds `id="mobile-menu"` to the mobile menu container.
- Adds a `useEffect` listener to support closing the menu with the `Escape` key, a critical feature for keyboard navigation users.
- Includes a new entry in `.jules/palette.md` outlining this UX/accessibility learning.

---
*PR created automatically by Jules for task [8311012801482476485](https://jules.google.com/task/8311012801482476485) started by @JonasAbde*