### PR TITLE
⚡ Bolt: Move imgMap out of component render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+## 2024-05-24 - Prevent Reallocation in Render Loops
+**Learning:** In React components like `Home.tsx`, defining static arrays or mappings (e.g. `imgMap`) inside `.map` render loops causes unnecessary dictionary reallocation on every iteration and render cycle, applying pressure on the garbage collector. While minor on its own, this is an anti-pattern that can compound in large lists.
+**Action:** Move static data objects to the module scope (outside component functions) and ensure to document the performance impact directly in the code with comments as per strict role guidelines.

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -24,6 +24,15 @@ const serviceTypes = [
   { id: "andet", label: "Andet" },
 ];
 
+// Extracted static array mapping out of the coreServices.map loop.
+// Impact: Prevents memory reallocation and garbage collection pressure on every render and iteration cycle.
+const imgMap: Record<string, string> = {
+  "fast-rengoering": "/images/service-fast.webp",
+  "flytterengoering": "/images/service-flyt.webp",
+  "hovedrengoering": "/images/service-hoved.webp",
+  "erhvervsrengoering": "/images/service-erhverv.webp",
+};
+
 function QuickQuoteForm() {
   const [formState, setFormState] = useState<FormState>("idle");
   const [serviceType, setServiceType] = useState("");
@@ -373,12 +382,6 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {coreServices.map((service, i) => {
               const Icon = service.icon;
-              const imgMap: Record<string, string> = {
-                "fast-rengoering": "/images/service-fast.webp",
-                "flytterengoering": "/images/service-flyt.webp",
-                "hovedrengoering": "/images/service-hoved.webp",
-                "erhvervsrengoering": "/images/service-erhverv.webp",
-              };
               const imgSrc = imgMap[service.id];
               return (
                 <Link


### PR DESCRIPTION
💡 **What:** Moved `imgMap` out of the `.map()` loop during rendering and placed it in the module scope at the top of `src/routes/Home.tsx`. Added comments to document the optimization directly in the code.

🎯 **Why:** Defining a dictionary or static array directly inside a map loop causes the object to be recreated on every single iteration across every render cycle. By hoisting the static dictionary into the module scope, we eliminate redundant re-allocations and relieve pressure on the garbage collector.

📊 **Impact:** Reduces memory allocation per render by n objects (where n is the number of core services) and lowers garbage collection pauses over time.

🔬 **Measurement:** Verified via application runtime that functionality persists seamlessly. Impact can be observed via React profiler, indicating slightly less time and memory consumed during rendering of the `Home` component.

---
*PR created automatically by Jules for task [13654326376543063712](https://jules.google.com/task/13654326376543063712) started by @JonasAbde*