### PR TITLE
🎨 Palette: Improve Mobile Menu Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-10 - Mobile Menu Accessibility
+**Learning:** Mobile dropdown menus are often overlooked for keyboard navigation and screen reader linking. Missing `Escape` key support traps keyboard users, and missing `aria-expanded`/`aria-controls` prevents screen readers from understanding the menu's state and relationship to the toggle button.
+**Action:** Always ensure mobile menu toggles have `aria-expanded` reflecting their state, `aria-controls` pointing to the menu container's ID, and an `Escape` key listener on the document to allow keyboard users to easily dismiss the menu.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -21,6 +21,17 @@ export default function Header() {
     if (path === "/" && location.pathname !== "/") return false;
     return location.pathname.startsWith(path) && path !== "/";
   };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobileMenuOpen]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-100 bg-white/80 backdrop-blur-md">
@@ -70,6 +81,8 @@ export default function Header() {
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -77,7 +90,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
🎨 Palette: Improve Mobile Menu Accessibility

💡 What:
- Added an `Escape` key event listener to allow users to close the mobile menu via keyboard.
- Added `aria-expanded`, `aria-controls`, and an `id="mobile-menu"` to the toggle button and menu container.

🎯 Why:
- Screen readers need `aria-expanded` and `aria-controls` to understand that a button controls a specific collapsible menu and to know its current state.
- Keyboard users and screen reader users expect to be able to close a modal or mobile menu by pressing `Escape`. Trapping them inside is a poor UX pattern.

♿ Accessibility:
- Addresses critical WCAG compliance for dropdowns and interactive menus by providing an alternative to mouse click and properly linking elements programmatically.

---
*PR created automatically by Jules for task [9757067241765844756](https://jules.google.com/task/9757067241765844756) started by @JonasAbde*