### PR TITLE
⚡ Bolt: Prevent re-allocation of static data structures

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+## 2024-05-24 - Avoid Static Arrays/Objects Inside Components
+**Learning:** React components that define static arrays or objects inside the component body, such as `navLinks` in `Header` or `imgMap` in `Home`, trigger a re-allocation of these data structures on every render cycle. This increases garbage collection pressure and can unnecessarily impact performance, especially in components that re-render frequently.
+**Action:** Move static data structures like configuration arrays and constant mapping objects outside of component definitions into the module scope.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,18 +4,18 @@ import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
 import { cn } from "@/lib/utils";
 
+const navLinks = [
+  { name: "Forside", path: "/" },
+  { name: "Om os", path: "/om-os" },
+  { name: "Services", path: "/services" },
+  { name: "Priser", path: "/priser" },
+  { name: "Guide", path: "/guides/saadan-bestaar-du-dit-flyttesyn" },
+  { name: "FAQ", path: "/faq" },
+];
+
 export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
-
-  const navLinks = [
-    { name: "Forside", path: "/" },
-    { name: "Om os", path: "/om-os" },
-    { name: "Services", path: "/services" },
-    { name: "Priser", path: "/priser" },
-    { name: "Guide", path: "/guides/saadan-bestaar-du-dit-flyttesyn" },
-    { name: "FAQ", path: "/faq" },
-  ];
 
   const isActive = (path: string) => {
     if (path === "/" && location.pathname !== "/") return false;

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -24,6 +24,13 @@ const serviceTypes = [
   { id: "andet", label: "Andet" },
 ];
 
+const imgMap: Record<string, string> = {
+  "fast-rengoering": "/images/service-fast.webp",
+  "flytterengoering": "/images/service-flyt.webp",
+  "hovedrengoering": "/images/service-hoved.webp",
+  "erhvervsrengoering": "/images/service-erhverv.webp",
+};
+
 function QuickQuoteForm() {
   const [formState, setFormState] = useState<FormState>("idle");
   const [serviceType, setServiceType] = useState("");
@@ -373,12 +380,6 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {coreServices.map((service, i) => {
               const Icon = service.icon;
-              const imgMap: Record<string, string> = {
-                "fast-rengoering": "/images/service-fast.webp",
-                "flytterengoering": "/images/service-flyt.webp",
-                "hovedrengoering": "/images/service-hoved.webp",
-                "erhvervsrengoering": "/images/service-erhverv.webp",
-              };
               const imgSrc = imgMap[service.id];
               return (
                 <Link


### PR DESCRIPTION
💡 **What:** Moved the `navLinks` array in `Header.tsx` and the `imgMap` object in `Home.tsx` outside of their respective component definitions to the module scope.
🎯 **Why:** Defining static data structures inside a React functional component causes them to be re-created on every single render. For components that might re-render often (like navigation headers or complex pages), this adds unnecessary memory pressure and garbage collection overhead.
📊 **Impact:** Eliminates completely unnecessary re-allocations of an array and an object on every render of these components. This is a standard React performance best practice that makes the components slightly leaner without sacrificing any readability.
🔬 **Measurement:** You can verify this by checking the memory profile in React DevTools, or simply observing that the components still function exactly as before but no longer instantiate these constants inside the render loop.

---
*PR created automatically by Jules for task [11597708132006571006](https://jules.google.com/task/11597708132006571006) started by @JonasAbde*