### PR TITLE
🛡️ Sentinel: [HIGH] Fix 500 server crash on invalid JSON payload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Type Confusion XSS in API sanitization (due to missing recursive sanitization) and potential Email Header Injection (due to CRLF injection in email subjects).
 **Learning:** Arrays and nested objects can bypass top-level string replacements and still invoke `toString()` during template interpolation resulting in XSS. User inputs mapped directly to email headers need explicit `\r\n` removal.
 **Prevention:** Always implement recursive object traversal for sanitization and strip CRLF inputs from headers explicitly.
+
+## 2026-05-10 - Protect Against 500 Crash on Invalid JSON Type
+**Vulnerability:** The API endpoint implicitly assumed that `request.json()` would return an object if it didn't throw a parsing error. By passing valid JSON that was not an object (e.g. `null` or arrays like `[]`), the input bypassed validation and threw a TypeError deep within the object sanitization logic, causing a 500 Internal Server Error crash.
+**Learning:** Parsing JSON without syntax errors does not guarantee the required data structure. Unhandled type mismatches in incoming payloads can lead to application crashes (Denial of Service) and obscure error traces.
+**Prevention:** Always explicitly verify the type of parsed JSON objects (e.g., `!data || typeof data !== 'object' || Array.isArray(data)`) to gracefully handle invalid payloads with a 400 Bad Request before attempting object traversal or property access.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -221,6 +221,14 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       });
     }
+
+    if (!rawData || typeof rawData !== 'object' || Array.isArray(rawData)) {
+      return new Response(JSON.stringify({ error: 'JSON body must be an object' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
     const data = sanitizeObject(rawData);
     
     const validationError = getValidationError(data);


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unhandled TypeError resulting in a 500 Internal Server Error crash when passing valid JSON primitives (e.g., `null`) or arrays (e.g., `[]`) to `request.json()`, bypassing expected plain-object validation before downstream object sanitization and property access.
🎯 **Impact:** Potential Denial of Service or unhandled application crashes leading to obscured, difficult-to-trace logs due to missing structural validation of user input.
🔧 **Fix:** Added explicit validation right after `request.json()` to reject `null`, arrays, or non-object primitives with a `400 Bad Request`, preventing the API from hitting downstream validation logic with incompatible types.
✅ **Verification:** Verified by throwing explicit edge case input (`null`) against a test script, running static linting, and compiling the app build via Vite. Appended relevant learning to the `Sentinel` journal under `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10241008014525374968](https://jules.google.com/task/10241008014525374968) started by @JonasAbde*