### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Unhandled Promise Rejection on request.json()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Type Confusion XSS in API sanitization (due to missing recursive sanitization) and potential Email Header Injection (due to CRLF injection in email subjects).
 **Learning:** Arrays and nested objects can bypass top-level string replacements and still invoke `toString()` during template interpolation resulting in XSS. User inputs mapped directly to email headers need explicit `\r\n` removal.
 **Prevention:** Always implement recursive object traversal for sanitization and strip CRLF inputs from headers explicitly.
+
+## 2025-02-28 - Unhandled Promise Rejection due to missing Type Check on request.json()
+**Vulnerability:** Application-level Denial of Service (DoS) due to missing type check when parsing JSON payloads (`request.json()`) in Cloudflare workers, causing 500 server crashes.
+**Learning:** `request.json()` catches syntax errors but does not validate the type of the parsed JSON payload. If a client sends a body of `null` or `true`, standard object destructuring or property access on the result (e.g. `data.companyWebsite`) will throw a `TypeError`, leading to an unhandled exception and 500 crash.
+**Prevention:** Always add a type check `if (!data || typeof data !== 'object' || Array.isArray(data))` after parsing `request.json()` to ensure the payload is a valid object before performing property accesses or validations. Return a 400 Bad Request if the type check fails.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -215,6 +215,9 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
     let rawData: Record<string, unknown>;
     try {
       rawData = await request.json() as Record<string, unknown>;
+      if (!rawData || typeof rawData !== 'object' || Array.isArray(rawData)) {
+        throw new Error('JSON is not an object');
+      }
     } catch {
       return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
         status: 400,


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** Application-level Denial of Service (DoS) due to missing type check when parsing JSON payloads (`request.json()`) in Cloudflare workers, causing 500 server crashes.
**🎯 Impact:** If a client sends a body of `null` or `true`, standard object destructuring or property access on the result (e.g. `data.companyWebsite`) will throw a `TypeError`, leading to an unhandled exception and 500 crash.
**🔧 Fix:** Added a type check `if (!rawData || typeof rawData !== 'object' || Array.isArray(rawData))` inside the try block to safely reject non-object payloads with a `400 Bad Request` before the data is sanitized and accessed.
**✅ Verification:** Ran test script sending a `null` payload body and verified it correctly caught the error and responded with a `400 Invalid JSON body` response instead of crashing with a `500 Server Error`. Passed all linting and type checks.

---
*PR created automatically by Jules for task [16154553763664003254](https://jules.google.com/task/16154553763664003254) started by @JonasAbde*