### PR TITLE
🎨 Palette: Improve mobile menu accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Mobile Menu Accessibility Pattern
+**Learning:** Adding an `Escape` key listener via `useEffect`, setting `aria-expanded` reflecting state, setting `aria-controls` to match the target element's ID (`id="mobile-menu"`) ensures correct screen reader and keyboard functionality. This ensures the component supports accessibility gracefully without needing third-party libraries for dialog interactions.
+**Action:** When creating any mobile menu or expanding navigation component, always implement these exact attributes (`aria-expanded`, `aria-controls`, `id` on target, and `Escape` key logic) to guarantee robust accessibility immediately.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -21,6 +21,17 @@ export default function Header() {
     if (path === "/" && location.pathname !== "/") return false;
     return location.pathname.startsWith(path) && path !== "/";
   };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobileMenuOpen]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-100 bg-white/80 backdrop-blur-md">
@@ -70,6 +81,8 @@ export default function Header() {
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -77,7 +90,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
**What:**
Added proper accessibility attributes to the mobile menu toggle button and container, and implemented keyboard support allowing the menu to be closed via the `Escape` key. Created an entry in `.jules/palette.md` documenting the required attributes and behaviors for accessible mobile menus within the codebase.

**Why:**
Screen reader users did not have sufficient context about the state of the mobile menu or its relationship to the toggle button. Keyboard users could not reliably close the menu via standard navigation flows.

**Accessibility Improvements:**
- `aria-expanded` dynamically reflects whether the mobile menu is open.
- `aria-controls="mobile-menu"` programmatically associates the button with the menu container.
- `id="mobile-menu"` added to the menu container to satisfy `aria-controls`.
- Added an `Escape` key listener via `useEffect` to enable keyboard users to dismiss the menu naturally.

---
*PR created automatically by Jules for task [1295363138562392781](https://jules.google.com/task/1295363138562392781) started by @JonasAbde*