### PR TITLE
⚡ Bolt: Prevent redundant object allocation for service images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+
+## 2024-05-25 - Prevent Redundant Object Allocation in .map Loops
+**Learning:** Defining static mapping objects (like `imgMap`) inside a `.map` callback or within the render loop causes unnecessary memory allocation and garbage collection pressure on every iteration and component render cycle.
+**Action:** Move static data structures (arrays, objects) that do not depend on component state or props outside the component to module scope.

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -24,6 +24,16 @@ const serviceTypes = [
   { id: "andet", label: "Andet" },
 ];
 
+// ⚡ Bolt: Moved static image map outside of the component to prevent
+// redundant object allocation and garbage collection on every render/iteration.
+// Impact: Reduces memory overhead and slightly speeds up rendering of the services list.
+const SERVICE_IMAGE_MAP: Record<string, string> = {
+  "fast-rengoering": "/images/service-fast.webp",
+  "flytterengoering": "/images/service-flyt.webp",
+  "hovedrengoering": "/images/service-hoved.webp",
+  "erhvervsrengoering": "/images/service-erhverv.webp",
+};
+
 function QuickQuoteForm() {
   const [formState, setFormState] = useState<FormState>("idle");
   const [serviceType, setServiceType] = useState("");
@@ -373,13 +383,7 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {coreServices.map((service, i) => {
               const Icon = service.icon;
-              const imgMap: Record<string, string> = {
-                "fast-rengoering": "/images/service-fast.webp",
-                "flytterengoering": "/images/service-flyt.webp",
-                "hovedrengoering": "/images/service-hoved.webp",
-                "erhvervsrengoering": "/images/service-erhverv.webp",
-              };
-              const imgSrc = imgMap[service.id];
+              const imgSrc = SERVICE_IMAGE_MAP[service.id];
               return (
                 <Link
                   key={i}


### PR DESCRIPTION
💡 **What:** Moved `imgMap` static mapping object out of the render loop to module scope as `SERVICE_IMAGE_MAP` in `src/routes/Home.tsx`. Added a new critical learning to `.jules/bolt.md`.
🎯 **Why:** Defining an object inline inside a `.map()` callback during rendering forces JavaScript to create and allocate a brand new object on every single loop iteration. This creates unnecessary memory overhead and short-lived objects that trigger frequent garbage collection, slowing down component rendering.
📊 **Impact:** Reduces memory overhead and garbage collection pressure, ensuring a smoother rendering cycle for the `Home` component.
🔬 **Measurement:** Verify via `pnpm build` and `pnpm lint` that functionality remains identical while preventing duplicate memory allocation.

---
*PR created automatically by Jules for task [9438214108974310293](https://jules.google.com/task/9438214108974310293) started by @JonasAbde*