### PR TITLE
🎨 Palette: Improve Mobile Menu Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-12 - [Accessibility for Mobile Menu Buttons]
+**Learning:** In React/Tailwind applications, simple icon-only mobile menu toggle buttons often lack structural ARIA attributes. A button merely toggling visual state isn't enough for screen readers. It needs `aria-expanded` and `aria-controls` explicitly tied to the menu element's ID to be accessible. Also, adding keyboard accessibility with the `Escape` key helps close modals/menus cleanly for non-mouse users.
+**Action:** When creating or modifying mobile menus or toggle buttons, always ensure `aria-expanded` is dynamically linked to state, `aria-controls` connects to the correct container `id`, and provide keyboard interaction (like Escape key closing) for a seamless experience.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -21,6 +21,16 @@ export default function Header() {
     if (path === "/" && location.pathname !== "/") return false;
     return location.pathname.startsWith(path) && path !== "/";
   };
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isMobileMenuOpen]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-100 bg-white/80 backdrop-blur-md">
@@ -70,6 +80,8 @@ export default function Header() {
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -77,7 +89,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
💡 **What**: Added `aria-expanded` and `aria-controls` attributes to the mobile menu toggle button, and introduced an `Escape` key listener to close the menu.

🎯 **Why**: To make the mobile menu accessible to screen readers by explicitly linking the button's state to the menu container, and to allow keyboard users to easily close the menu.

📸 **Before/After**: Visually identical, but functionally superior for keyboard and screen reader users.

♿ **Accessibility**: Enhanced structural ARIA support and improved keyboard interaction for the mobile menu.

---
*PR created automatically by Jules for task [7414819604641548232](https://jules.google.com/task/7414819604641548232) started by @JonasAbde*