### PR TITLE
🎨 Palette: Enhance mobile menu accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-24 - Mobile Menu Accessibility Enhancements
+**Learning:** For mobile menu toggle buttons, simply adding an `aria-label` is not enough for full accessibility. They must include `aria-expanded` reflecting the current open/closed state, `aria-controls` pointing to the menu container's ID, and an `Escape` key listener on the document to allow users to easily close the menu with the keyboard, which ensures correct screen reader and keyboard support.
+**Action:** When implementing or reviewing mobile menus or similar toggleable UI components, always ensure these three critical accessibility features (`aria-expanded`, `aria-controls`, and `Escape` key support) are present.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -21,6 +21,18 @@ export default function Header() {
     if (path === "/" && location.pathname !== "/") return false;
     return location.pathname.startsWith(path) && path !== "/";
   };
+
+  // Close mobile menu on escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isMobileMenuOpen]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-100 bg-white/80 backdrop-blur-md">
@@ -69,6 +81,8 @@ export default function Header() {
         <button
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -77,7 +91,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
This PR adds necessary accessibility improvements to the mobile menu component (`Header.tsx`):
- **Escape key listener**: Allows keyboard users to easily close the mobile menu using the Escape key.
- **aria-expanded**: Indicates the open/close state of the mobile menu to assistive technologies.
- **aria-controls**: Associates the toggle button with the mobile menu content it controls.

Also added a journal entry in `.Jules/palette.md` to document the learnings from this UX enhancement.

---
*PR created automatically by Jules for task [223373425965157776](https://jules.google.com/task/223373425965157776) started by @JonasAbde*