### PR TITLE
⚡ Bolt: Prevent redundant memory allocation in render loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+
+## 2024-05-24 - Prevent Redundant Memory Allocation in Loops and Renders
+**Learning:** Defining static mappings (arrays or objects) inside React component definitions or `.map()` loops causes them to be re-allocated on every iteration and render cycle. This causes unnecessary garbage collection pressure and can lead to performance regressions.
+**Action:** Always move static arrays and objects that map values outside the component to module scope as constants.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,18 +4,19 @@ import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
 import { cn } from "@/lib/utils";
 
+// ⚡ Bolt: Moved static navigation array to module scope to prevent reallocation on every component render
+const navLinks = [
+  { name: "Forside", path: "/" },
+  { name: "Om os", path: "/om-os" },
+  { name: "Services", path: "/services" },
+  { name: "Priser", path: "/priser" },
+  { name: "Guide", path: "/guides/saadan-bestaar-du-dit-flyttesyn" },
+  { name: "FAQ", path: "/faq" },
+];
+
 export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
-
-  const navLinks = [
-    { name: "Forside", path: "/" },
-    { name: "Om os", path: "/om-os" },
-    { name: "Services", path: "/services" },
-    { name: "Priser", path: "/priser" },
-    { name: "Guide", path: "/guides/saadan-bestaar-du-dit-flyttesyn" },
-    { name: "FAQ", path: "/faq" },
-  ];
 
   const isActive = (path: string) => {
     if (path === "/" && location.pathname !== "/") return false;

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -24,6 +24,14 @@ const serviceTypes = [
   { id: "andet", label: "Andet" },
 ];
 
+// ⚡ Bolt: Moved static image map to module scope to prevent reallocation on every render loop iteration
+const SERVICE_IMAGE_MAP: Record<string, string> = {
+  "fast-rengoering": "/images/service-fast.webp",
+  "flytterengoering": "/images/service-flyt.webp",
+  "hovedrengoering": "/images/service-hoved.webp",
+  "erhvervsrengoering": "/images/service-erhverv.webp",
+};
+
 function QuickQuoteForm() {
   const [formState, setFormState] = useState<FormState>("idle");
   const [serviceType, setServiceType] = useState("");
@@ -373,13 +381,7 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {coreServices.map((service, i) => {
               const Icon = service.icon;
-              const imgMap: Record<string, string> = {
-                "fast-rengoering": "/images/service-fast.webp",
-                "flytterengoering": "/images/service-flyt.webp",
-                "hovedrengoering": "/images/service-hoved.webp",
-                "erhvervsrengoering": "/images/service-erhverv.webp",
-              };
-              const imgSrc = imgMap[service.id];
+              const imgSrc = SERVICE_IMAGE_MAP[service.id];
               return (
                 <Link
                   key={i}


### PR DESCRIPTION
What: Moved static `navLinks` array and `imgMap` object outside of React components.
Why: Defining static values inside render functions and `.map()` iterations causes unnecessary garbage collection and memory reallocation on each render loop, negatively impacting performance.
Impact: Reduces memory pressure and limits unnecessary work during render cycles.
Measurement: Compare memory allocation profile during render loops before and after patch.

---
*PR created automatically by Jules for task [2897649715102041415](https://jules.google.com/task/2897649715102041415) started by @JonasAbde*