### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix rate limiter memory leak and bypass risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Type Confusion XSS in API sanitization (due to missing recursive sanitization) and potential Email Header Injection (due to CRLF injection in email subjects).
 **Learning:** Arrays and nested objects can bypass top-level string replacements and still invoke `toString()` during template interpolation resulting in XSS. User inputs mapped directly to email headers need explicit `\r\n` removal.
 **Prevention:** Always implement recursive object traversal for sanitization and strip CRLF inputs from headers explicitly.
+
+## 2024-05-13 - [Fix Rate Limiter Memory Leak and Bypass Risk]
+**Vulnerability:** The in-memory `rateLimitHits` Map in Cloudflare Pages Functions (which run in long-lived isolates) grew unboundedly for every unique IP. This caused memory exhaustion (OOM), leading the isolate to restart and flush the Map, effectively bypassing rate limits for all current users during high-traffic bursts.
+**Learning:** In long-lived serverless isolates, global state (like Maps) persists across requests. A lack of size bounds leads to memory leaks, and naive solutions like calling `map.clear()` when full cause a reset of rate limit data for all users, introducing a bypass vulnerability during peak abuse.
+**Prevention:** Always implement a bounded map check that selectively removes expired entries instead of clearing the entire map or letting it grow infinitely.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -54,6 +54,17 @@ function getClientIp(headers: HeaderReader): string {
 }
 
 function isRateLimited(headers: HeaderReader): boolean {
+  // Prevent memory leak in long-lived isolates by cleaning up stale entries
+  // Crucial: avoid clear() which resets rate limits for all current users and causes bypass
+  if (rateLimitHits.size > 1000) {
+    const now = Date.now();
+    for (const [k, hits] of rateLimitHits.entries()) {
+      const validHits = hits.filter((hit) => now - hit < RATE_LIMIT_WINDOW_MS);
+      if (validHits.length === 0) rateLimitHits.delete(k);
+      else rateLimitHits.set(k, validHits);
+    }
+  }
+
   const key = getClientIp(headers);
   const now = Date.now();
   const recentHits = (rateLimitHits.get(key) || []).filter((hit) => now - hit < RATE_LIMIT_WINDOW_MS);


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `rateLimitHits` Map in `functions/api/quote.ts` grows infinitely for every unique IP. In long-lived serverless isolates, this causes memory exhaustion (OOM), leading to isolate restarts. The naive fix of calling `map.clear()` when full would reset rate limits for all current users, introducing a bypass vulnerability during high-traffic bursts.
🎯 **Impact:** Potential memory leak resulting in 500 errors or a reset of security limits allowing abuse and spam of the Resend API endpoint.
🔧 **Fix:** Added a bounded check that selectively iterates and deletes expired entries once the map size exceeds 1,000, avoiding a full reset while fixing the memory leak.
✅ **Verification:** Verified by building and reviewing the logic. The logic safely mutates the map while iterating without disrupting active valid rate limits. Recorded in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5198130416539985217](https://jules.google.com/task/5198130416539985217) started by @JonasAbde*