### PR TITLE
🎨 Palette: Improve mobile menu accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-15 - Explicit ARIA Labels and Keyboard Handlers for Mobile Menus
+**Learning:** Mobile menu toggle buttons should provide the necessary ARIA attributes to accurately reflect their expanded/collapsed state and what they control. While adding `aria-label` is a good first step, screen readers additionally need `aria-expanded` and `aria-controls` to be truly accessible. Providing a listener to close an open menu with the `Escape` key further improves accessibility.
+**Action:** When creating mobile or dropdown menus, ensure the toggle button has `aria-expanded` reflecting the menu state, `aria-controls` pointing to the menu container's ID, and that an `Escape` key listener on the document closes the menu.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -7,6 +7,16 @@ import { cn } from "@/lib/utils";
 export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isMobileMenuOpen]);
 
   const navLinks = [
     { name: "Forside", path: "/" },
@@ -69,6 +79,8 @@ export default function Header() {
         <button
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -77,7 +89,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
💡 **What:** Added missing ARIA attributes (`aria-expanded`, `aria-controls`) to the mobile menu toggle button, added an `id` to the menu container, and implemented an `Escape` key listener to close the mobile menu.
🎯 **Why:** Mobile menu toggle buttons require `aria-expanded` and `aria-controls` for screen readers to accurately communicate their state. Additionally, keyboard users expect to be able to close open modals and menus using the `Escape` key.
♿ **Accessibility:** This ensures screen readers announce the state of the menu and keyboard users can easily close it, addressing critical WCAG accessibility standards.

---
*PR created automatically by Jules for task [8449300428180271458](https://jules.google.com/task/8449300428180271458) started by @JonasAbde*