### PR TITLE
🛡️ Sentinel: [HIGH] Fix Type Confusion DoS in JSON Parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Type Confusion XSS in API sanitization (due to missing recursive sanitization) and potential Email Header Injection (due to CRLF injection in email subjects).
 **Learning:** Arrays and nested objects can bypass top-level string replacements and still invoke `toString()` during template interpolation resulting in XSS. User inputs mapped directly to email headers need explicit `\r\n` removal.
 **Prevention:** Always implement recursive object traversal for sanitization and strip CRLF inputs from headers explicitly.
+
+## 2024-05-16 - [Fix Type Confusion DoS in JSON Parser]
+**Vulnerability:** The application was vulnerable to a Denial of Service (DoS) due to type confusion in the `/api/quote` endpoint. If an attacker provided a JSON payload of `null` or an array, `request.json()` would successfully parse it, bypassing the `try-catch` block. However, subsequent code assumed the payload was an object and attempted to access properties (e.g., `data.companyWebsite`), throwing an unhandled `TypeError` that crashed the worker execution.
+**Learning:** `request.json()` and `JSON.parse()` can return primitive values like `null`, strings, numbers, or arrays—not just objects. Typing the result as `Record<string, unknown>` does not magically enforce object structure at runtime.
+**Prevention:** Always explicitly check the type and structure of parsed JSON payloads using defensive programming (`!data || typeof data !== 'object' || Array.isArray(data)`) before destructuring or accessing properties to prevent runtime crashes.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -221,6 +221,15 @@ export async function onRequest(context: EventContext<Env, string, unknown>): Pr
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       });
     }
+
+    // Prevent Type Confusion / DoS: Ensure rawData is actually an object and not null/array
+    if (!rawData || typeof rawData !== 'object' || Array.isArray(rawData)) {
+      return new Response(JSON.stringify({ error: 'Invalid JSON structure' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
     const data = sanitizeObject(rawData);
     
     const validationError = getValidationError(data);


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Type Confusion DoS. If an attacker submits a literal string like `"null"` or an array `[1,2]` as JSON, the worker successfully parses it but throws a `TypeError` when accessing properties, crashing the process.
🎯 **Impact:** Application crash resulting in a 500 error instead of a graceful 400 Bad Request.
🔧 **Fix:** Added an explicit safety check `!rawData || typeof rawData !== 'object' || Array.isArray(rawData)` immediately after JSON parsing.
✅ **Verification:** Verified locally with a simulation script and confirmed via `pnpm lint` and `pnpm build`.

---
*PR created automatically by Jules for task [17709479510535620546](https://jules.google.com/task/17709479510535620546) started by @JonasAbde*