### PR TITLE
🎨 Palette: Improve mobile menu accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+## 2025-05-17 - Mobile Menu Accessibility Enhancements
+**Learning:** For mobile menu toggles to be fully accessible, they must include `aria-expanded` (to reflect the open/closed state) and `aria-controls` (pointing to the menu container's ID). Additionally, capturing the `Escape` key to close the menu ensures proper keyboard navigation support.
+**Action:** When implementing or reviewing mobile menus, always ensure the toggle button has `aria-expanded` and `aria-controls`, and the menu itself can be dismissed with the `Escape` key.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -7,6 +7,17 @@ import { cn } from "@/lib/utils";
 export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isMobileMenuOpen]);
 
   const navLinks = [
     { name: "Forside", path: "/" },
@@ -70,6 +81,8 @@ export default function Header() {
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -77,7 +90,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
### 💡 What
Added semantic ARIA attributes (`aria-expanded`, `aria-controls`) to the mobile menu toggle and an `Escape` key listener to close the menu.

### 🎯 Why
To ensure the mobile navigation menu is fully accessible for screen reader users and keyboard navigators, conforming to standard a11y patterns.

### ♿ Accessibility
- Added `aria-expanded` to communicate the open/closed state to screen readers.
- Added `aria-controls` and `id="mobile-menu"` to explicitly link the toggle to the menu container.
- Added `Escape` key functionality for intuitive keyboard dismissal.

---
*PR created automatically by Jules for task [16663266651896805911](https://jules.google.com/task/16663266651896805911) started by @JonasAbde*