### PR TITLE
⚡ Bolt: Move static mapping object out of render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
+## 2024-05-24 - Prevent Redundant Computations with useMemo
+**Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
+**Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
 
 ## 2024-05-25 - Prevent Re-allocation in map Callbacks
 **Learning:** Instantiating static objects (e.g. `const imgMap = {...}`) inside a `.map()` callback or within a component body causes the object to be newly allocated on every iteration/render. This creates unnecessary garbage collection overhead.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,4 @@
-## 2024-05-24 - Prevent Redundant Computations with useMemo
-**Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
-**Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+
+## 2024-05-25 - Prevent Re-allocation in map Callbacks
+**Learning:** Instantiating static objects (e.g. `const imgMap = {...}`) inside a `.map()` callback or within a component body causes the object to be newly allocated on every iteration/render. This creates unnecessary garbage collection overhead.
+**Action:** Move static mapping objects out of the component body to module scope so they are only allocated once.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,6 +1,3 @@
-## 2024-05-24 - Prevent Redundant Computations with useMemo
-**Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
-**Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
 
 ## 2024-05-25 - Prevent Re-allocation in map Callbacks
 **Learning:** Instantiating static objects (e.g. `const imgMap = {...}`) inside a `.map()` callback or within a component body causes the object to be newly allocated on every iteration/render. This creates unnecessary garbage collection overhead.

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -24,6 +24,18 @@ const serviceTypes = [
   { id: "andet", label: "Andet" },
 ];
 
+// ⚡ Bolt Optimization: Moved static image mapping out of component render
+// What: Extracted imgMap from inside coreServices.map()
+// Why: Prevents re-allocating this object on every render cycle and array iteration
+// Impact: Reduces garbage collection pressure and saves memory allocation time
+// Measurement: Profile React renders - array iteration will be slightly faster
+const SERVICE_IMAGE_MAP: Record<string, string> = {
+  "fast-rengoering": "/images/service-fast.webp",
+  "flytterengoering": "/images/service-flyt.webp",
+  "hovedrengoering": "/images/service-hoved.webp",
+  "erhvervsrengoering": "/images/service-erhverv.webp",
+};
+
 function QuickQuoteForm() {
   const [formState, setFormState] = useState<FormState>("idle");
   const [serviceType, setServiceType] = useState("");
@@ -373,13 +385,7 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {coreServices.map((service, i) => {
               const Icon = service.icon;
-              const imgMap: Record<string, string> = {
-                "fast-rengoering": "/images/service-fast.webp",
-                "flytterengoering": "/images/service-flyt.webp",
-                "hovedrengoering": "/images/service-hoved.webp",
-                "erhvervsrengoering": "/images/service-erhverv.webp",
-              };
-              const imgSrc = imgMap[service.id];
+              const imgSrc = SERVICE_IMAGE_MAP[service.id];
               return (
                 <Link
                   key={i}

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -24,11 +24,7 @@ const serviceTypes = [
   { id: "andet", label: "Andet" },
 ];
 
-// ⚡ Bolt Optimization: Moved static image mapping out of component render
-// What: Extracted imgMap from inside coreServices.map()
-// Why: Prevents re-allocating this object on every render cycle and array iteration
-// Impact: Reduces garbage collection pressure and saves memory allocation time
-// Measurement: Profile React renders - array iteration will be slightly faster
+// ⚡ Bolt: Moved mapping out of render loop to prevent re-allocation
 const SERVICE_IMAGE_MAP: Record<string, string> = {
   "fast-rengoering": "/images/service-fast.webp",
   "flytterengoering": "/images/service-flyt.webp",


### PR DESCRIPTION
💡 **What:** Extracted the `imgMap` static mapping object from inside the `coreServices.map()` loop in `src/routes/Home.tsx` and placed it in the module scope as `SERVICE_IMAGE_MAP`.

🎯 **Why:** To prevent the object from being newly allocated on every single render cycle and on every iteration of the array. Creating static objects inside functional components or `.map` callbacks is a known React anti-pattern that causes unnecessary garbage collection overhead.

📊 **Impact:** Reduces memory allocation overhead and garbage collection pressure during renders. Array iterations will be slightly faster, making the hot path cleaner.

🔬 **Measurement:** While the absolute time saved per render is small, profiling React renders will show fewer allocations. Verified the change compiles and passes lint/build checks locally without introducing regressions.

---
*PR created automatically by Jules for task [12207645474024066592](https://jules.google.com/task/12207645474024066592) started by @JonasAbde*