### PR TITLE
⚡ Bolt: Move static navLinks outside Header component

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+## 2024-05-24 - Prevent Re-allocation of Static Arrays
+**Learning:** Static arrays or objects used inside React components (e.g., `const navLinks = [...]` inside `Header`) are unnecessarily re-allocated and garbage-collected on every re-render.
+**Action:** Move static data structures outside the component function body to the module scope to improve render performance and reduce memory pressure.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,18 +4,22 @@ import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
 import { cn } from "@/lib/utils";
 
+// ⚡ Bolt Performance Optimization:
+// Moved the static navLinks array outside the component to the module scope.
+// This prevents the array from being re-allocated and garbage-collected on every
+// component render (e.g., when toggling the mobile menu state), improving performance.
+const navLinks = [
+  { name: "Forside", path: "/" },
+  { name: "Om os", path: "/om-os" },
+  { name: "Services", path: "/services" },
+  { name: "Priser", path: "/priser" },
+  { name: "Guide", path: "/guides/saadan-bestaar-du-dit-flyttesyn" },
+  { name: "FAQ", path: "/faq" },
+];
+
 export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
-
-  const navLinks = [
-    { name: "Forside", path: "/" },
-    { name: "Om os", path: "/om-os" },
-    { name: "Services", path: "/services" },
-    { name: "Priser", path: "/priser" },
-    { name: "Guide", path: "/guides/saadan-bestaar-du-dit-flyttesyn" },
-    { name: "FAQ", path: "/faq" },
-  ];
 
   const isActive = (path: string) => {
     if (path === "/" && location.pathname !== "/") return false;


### PR DESCRIPTION
### What
Moved the static `navLinks` array in `src/components/layout/Header.tsx` outside of the `Header` component function body to the module scope.

### Why
Static data structures defined inside a React component are re-created (re-allocated) on every single render cycle. In the case of the `Header` component, this happens every time the mobile menu is toggled. Moving it to the module scope ensures it is only created once.

### Impact
Reduces unnecessary memory allocation and garbage collection overhead during React render cycles, slightly improving runtime performance and reducing memory pressure, especially on lower-end mobile devices during interactions like menu toggling.

### Measurement
The improvement can be verified by observing fewer object allocations in a memory profile during `Header` component re-renders (e.g., when repeatedly opening and closing the mobile menu). Passed all build and lint checks to ensure no functionality is affected.

---
*PR created automatically by Jules for task [16872959205636933263](https://jules.google.com/task/16872959205636933263) started by @JonasAbde*