### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limiting IP spoofing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A missing type check for JSON payloads returned by `request.json()` caused 500 Internal Server errors when iterating over objects like `null` or `Array`, and a missing mechanism to clean up the `rateLimitHits` Map caused infinite memory growth resulting in a DoS vulnerability.
 **Learning:** Type validation is necessary for payloads parsed through `request.json()`, and in-memory Map rate limiters need a time-throttled cleanup mechanism.
 **Prevention:** Verify JSON payload types `if (!data || typeof data !== 'object' || Array.isArray(data))` before destructuring/object iteration. Use a time-throttled approach like `if (Date.now() - lastCleanupTime > interval)` to selectively clean up Map rate limiters without introducing high CPU utilization vulnerabilities.
+
+## 2026-05-19 - [Fix Rate Limiting IP Spoofing Vulnerability]
+**Vulnerability:** The rate limiter's `getClientIp` function fell back to the `X-Forwarded-For` header if `CF-Connecting-IP` was missing. Because `X-Forwarded-For` is a standard HTTP header that can be easily manipulated by clients, attackers could spoof their IP address on every request to entirely bypass the rate limit.
+**Learning:** In edge environments like Cloudflare Workers, only rely on platform-provided, verified headers (like `CF-Connecting-IP`) to identify clients for security controls. Never trust client-provided headers like `X-Forwarded-For` or `True-Client-IP` for authentication, authorization, or rate limiting purposes unless you control the proxy layer that sets them.
+**Prevention:** Remove all fallbacks to `X-Forwarded-For` in `getClientIp` and explicitly depend on `CF-Connecting-IP` or fallback to `'unknown'` in local environments.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -50,9 +50,9 @@ type HeaderReader = {
 };
 
 function getClientIp(headers: HeaderReader): string {
-  return headers.get('CF-Connecting-IP') ||
-    headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
-    'unknown';
+  // Use CF-Connecting-IP provided by Cloudflare.
+  // Avoid falling back to X-Forwarded-For as it can be easily spoofed by clients to bypass rate limiting.
+  return headers.get('CF-Connecting-IP') || 'unknown';
 }
 
 function isRateLimited(headers: HeaderReader): boolean {


### PR DESCRIPTION
*   🚨 **Severity:** HIGH
*   💡 **Vulnerability:** The rate limiter relied on `X-Forwarded-For` as a fallback if `CF-Connecting-IP` was missing, allowing clients to spoof their IP address.
*   🎯 **Impact:** Attackers could easily bypass the rate limit and potentially exhaust resources or abuse the Resend API.
*   🔧 **Fix:** Removed the `X-Forwarded-For` fallback, ensuring only `CF-Connecting-IP` is used for rate limiting in edge environments.
*   ✅ **Verification:** Ran `pnpm build` and `pnpm lint` successfully.

---
*PR created automatically by Jules for task [8243698960383670984](https://jules.google.com/task/8243698960383670984) started by @JonasAbde*