### PR TITLE
🎨 Palette: Improve accessibility of mobile menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-20 - Accessible Mobile Menus
+**Learning:** Mobile menu toggle buttons should always include `aria-expanded` and `aria-controls` to reflect state to screen readers. The mobile menu itself should also close when the `Escape` key is pressed for keyboard navigation.
+**Action:** When implementing or modifying mobile menus, ensure these attributes and the `Escape` key handler are included.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -21,6 +21,16 @@ export default function Header() {
     if (path === "/" && location.pathname !== "/") return false;
     return location.pathname.startsWith(path) && path !== "/";
   };
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isMobileMenuOpen]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-100 bg-white/80 backdrop-blur-md">
@@ -70,6 +80,8 @@ export default function Header() {
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -77,7 +89,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
💡 **What:** The UX enhancement added:
  - Added `aria-expanded` to the mobile menu toggle to indicate if the menu is open or closed.
  - Added `aria-controls` to link the toggle with the mobile navigation container.
  - Implemented keyboard accessibility by allowing the mobile menu to be closed with the `Escape` key.
  
🎯 **Why:** The user problem it solves:
  - Screen reader users were previously unable to determine the state of the mobile menu or identify which element the toggle controlled.
  - Keyboard-only users were forced to tab through the entire menu or specifically find the close button to dismiss the mobile menu, creating friction.

♿ **Accessibility:**
  - Added crucial ARIA attributes (`aria-expanded`, `aria-controls`) to the mobile menu toggle.
  - Added `id="mobile-menu"` to the target container.
  - Added a global `Escape` key event listener that dismisses the mobile menu, restoring focus context intuitively.

---
*PR created automatically by Jules for task [3860493442904240783](https://jules.google.com/task/3860493442904240783) started by @JonasAbde*