### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP spoofing vulnerability in rate limiting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A missing type check for JSON payloads returned by `request.json()` caused 500 Internal Server errors when iterating over objects like `null` or `Array`, and a missing mechanism to clean up the `rateLimitHits` Map caused infinite memory growth resulting in a DoS vulnerability.
 **Learning:** Type validation is necessary for payloads parsed through `request.json()`, and in-memory Map rate limiters need a time-throttled cleanup mechanism.
 **Prevention:** Verify JSON payload types `if (!data || typeof data !== 'object' || Array.isArray(data))` before destructuring/object iteration. Use a time-throttled approach like `if (Date.now() - lastCleanupTime > interval)` to selectively clean up Map rate limiters without introducing high CPU utilization vulnerabilities.
+
+## 2024-05-21 - [HIGH] Fix IP spoofing vulnerability in rate limiting
+**Vulnerability:** IP Spoofing via X-Forwarded-For fallback bypassing rate limits
+**Learning:** Cloudflare Pages Functions use `CF-Connecting-IP` for client IP, but falling back to `X-Forwarded-For` allows attackers to easily spoof their IP address by injecting this header, thereby bypassing rate limits and security controls.
+**Prevention:** Rely strictly on `CF-Connecting-IP` in Cloudflare environments and fail securely to a shared fallback (like 'unknown') instead of trusting easily spoofed headers like `X-Forwarded-For`.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -50,9 +50,8 @@ type HeaderReader = {
 };
 
 function getClientIp(headers: HeaderReader): string {
-  return headers.get('CF-Connecting-IP') ||
-    headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
-    'unknown';
+  // Use CF-Connecting-IP to prevent IP spoofing attacks via X-Forwarded-For
+  return headers.get('CF-Connecting-IP') || 'unknown';
 }
 
 function isRateLimited(headers: HeaderReader): boolean {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application's rate limiter previously attempted to retrieve the user's IP via `CF-Connecting-IP`, falling back to `X-Forwarded-For`. The `X-Forwarded-For` header is completely controllable by malicious actors. In an environment configured by Cloudflare Pages/Workers, falling back to this header introduces an easy rate limiting bypass where an attacker injects new `X-Forwarded-For` headers iteratively to evade throttling controls.
🎯 **Impact:** Malicious actors could bypass rate limiting limits via script and exhaust quota, leading to a potential Denial-of-Service and exhaustion of the paid Resend API limit quota.
🔧 **Fix:** Hardened the Cloudflare IP check `getClientIp` function to strictly rely on the injected `CF-Connecting-IP` header without falling back to easily spoofed headers, adhering strictly to Zero Trust. If `CF-Connecting-IP` is stripped, it safely falls back to a shared bucket ('unknown').
✅ **Verification:** Verified by building and running tests. No unmanaged regressions introduced. Added documented Sentinel learning entry.

---
*PR created automatically by Jules for task [16383341393536499755](https://jules.google.com/task/16383341393536499755) started by @JonasAbde*