### PR TITLE
🎨 Palette: Mobile Menu Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-18 - Mobile Menu Toggle Accessibility
+**Learning:** For accessibility, mobile menu toggle buttons must include `aria-expanded` reflecting the menu state, `aria-controls` pointing to the menu container's ID, and an `Escape` key listener on the document to ensure correct keyboard and screen reader support.
+**Action:** When implementing togglable UI elements like mobile menus or accordions, ensure the element is linked to its controlled content using `aria-controls`, its state is exposed via `aria-expanded`, and a keyboard user can dismiss the content using the Escape key.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -21,6 +21,16 @@ export default function Header() {
     if (path === "/" && location.pathname !== "/") return false;
     return location.pathname.startsWith(path) && path !== "/";
   };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobileMenuOpen]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-100 bg-white/80 backdrop-blur-md">
@@ -69,6 +79,8 @@ export default function Header() {
         <button
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -77,7 +89,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
This PR enhances the accessibility of the mobile menu toggle by:
1. Adding `aria-expanded` and `aria-controls` to the mobile menu button to communicate its state and relationship to the menu container to assistive technologies.
2. Adding an `id` to the mobile menu container to support the `aria-controls` attribute.
3. Adding a `useEffect` hook that listens for the 'Escape' key, allowing keyboard users to easily dismiss the menu when it's open.
4. Documenting this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [13338084854787402515](https://jules.google.com/task/13338084854787402515) started by @JonasAbde*