### PR TITLE
⚡ Bolt: Hoist massive static schemas to module scope

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+## 2024-05-24 - Hoist massive static schemas to module scope
+**Learning:** Large static objects like JSON-LD schemas declared inside React components are re-created on every render, adding unnecessary memory overhead and garbage collection pressure.
+**Action:** Move massive static structures (e.g. `localBusinessSchema`, `organizationSchema`) to the module scope outside of the component to improve performance. Maintain dynamic state structures inside the component.

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -35,24 +35,10 @@ function getBreadcrumbItems(pathname: string) {
   return items;
 }
 
-export default function StructuredData() {
-  const { pathname } = useLocation();
-  const breadcrumbItems = getBreadcrumbItems(pathname);
+const areaNames = geography.areas.map((a) => a.city);
 
-  const breadcrumbSchema = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: breadcrumbItems.map((item, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      name: item.name,
-      item: `${SITE_URL}${item.path}`,
-    })),
-  };
-
-  const areaNames = geography.areas.map((a) => a.city);
-
-  const localBusinessSchema = {
+// Hoist massive static objects outside the component to prevent garbage collection pressure on every render.
+const localBusinessSchema = {
     "@context": "https://schema.org",
     "@type": "LocalBusiness",
     name: company.name,
@@ -212,7 +198,7 @@ export default function StructuredData() {
     paymentAccepted: ["Kontant", "Bankoverførsel", "MobilePay"],
   };
 
-  const websiteSchema = {
+const websiteSchema = {
     "@context": "https://schema.org",
     "@type": "WebSite",
     name: company.name,
@@ -220,7 +206,7 @@ export default function StructuredData() {
     inLanguage: "da-DK",
   };
 
-  const organizationSchema = {
+const organizationSchema = {
     "@context": "https://schema.org",
     "@type": "Organization",
     name: company.name,
@@ -236,6 +222,21 @@ export default function StructuredData() {
       contactType: "customer service",
       availableLanguage: ["Danish"],
     },
+  };
+
+export default function StructuredData() {
+  const { pathname } = useLocation();
+  const breadcrumbItems = getBreadcrumbItems(pathname);
+
+  const breadcrumbSchema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: breadcrumbItems.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: `${SITE_URL}${item.path}`,
+    })),
   };
 
   useEffect(() => {


### PR DESCRIPTION
**💡 What:** 
Hoisted massive static JSON-LD schema objects (`localBusinessSchema`, `organizationSchema`, `websiteSchema`, and `areaNames`) outside the `StructuredData` component into the module scope in `src/components/StructuredData.tsx`.

**🎯 Why:**
Large static objects declared inside React components are re-created in memory on every render. Given the size of these schemas, doing so adds unnecessary memory overhead and garbage collection pressure, negatively impacting performance.

**📊 Impact:**
Eliminates the repeated creation of large static objects on every render, significantly reducing garbage collection (GC) pressure and improving overall memory efficiency and performance.

**🔬 Measurement:**
Can be verified by profiling component re-renders and memory allocations in React DevTools. The codebase was successfully verified with `pnpm lint` and `pnpm build`. Added a journal entry to `.jules/bolt.md` documenting this performance best practice.

---
*PR created automatically by Jules for task [14820835820248478480](https://jules.google.com/task/14820835820248478480) started by @JonasAbde*