### PR TITLE
🎨 Palette: Improve mobile menu accessibility and keyboard UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-23 - Mobile Menu Accessibility and Keyboard UX
+**Learning:** A standard mobile menu toggle using `lucide-react` icons and a state boolean lacks full accessibility out of the box. Screen readers rely on `aria-expanded` to know the menu's state and `aria-controls` referencing the menu's `id` to understand the connection. Additionally, keyboard users expect to be able to close an overlay/menu by pressing the `Escape` key, which requires a global event listener when the menu is open.
+**Action:** When creating or updating toggleable mobile menus or overlays, always include `aria-expanded` and `aria-controls` on the toggle button, ensure the menu container has the corresponding `id`, and implement a `useEffect` hook to listen for the `Escape` keydown event to dismiss the menu.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -21,6 +21,16 @@ export default function Header() {
     if (path === "/" && location.pathname !== "/") return false;
     return location.pathname.startsWith(path) && path !== "/";
   };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobileMenuOpen]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-100 bg-white/80 backdrop-blur-md">
@@ -70,6 +80,8 @@ export default function Header() {
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -77,7 +89,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
**What**: Added `aria-expanded` and `aria-controls` to the mobile menu toggle button, added an `id` to the mobile menu container, and implemented a `useEffect` listener to allow dismissing the menu via the `Escape` key.
**Why**: These additions improve the accessibility of the mobile menu for screen readers by providing proper context and state information, and they enhance the UX for keyboard navigators who expect overlays to be dismissible via the Escape key.
**Accessibility**: Proper ARIA states linking the toggle and the content, plus standard `Escape` dismissal UX.

A new entry was also added to `.Jules/palette.md` detailing these learnings.

---
*PR created automatically by Jules for task [12329977660554087845](https://jules.google.com/task/12329977660554087845) started by @JonasAbde*