### PR TITLE
⚡ Bolt: Eager load Home route to improve FCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+## 2024-05-24 - Eager Load Initial Route to Improve FCP
+**Learning:** Using `React.lazy()` for the initial/root route component (e.g., `Home` in `src/App.tsx`) introduces an unnecessary network roundtrip that delays the First Contentful Paint (FCP).
+**Action:** Eagerly import critical initial routes to avoid network waterfalls and ensure faster perceived performance on initial load.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,9 @@ import { HelmetProvider } from "react-helmet-async";
 import Layout from "./components/layout/Layout";
 import ScrollToTop from "./components/layout/ScrollToTop";
 
-const Home = React.lazy(() => import("./routes/Home"));
+// Eagerly load the initial route to improve First Contentful Paint (FCP)
+// by avoiding an unnecessary network roundtrip on initial load.
+import Home from "./routes/Home";
 const About = React.lazy(() => import("./routes/About"));
 const Services = React.lazy(() => import("./routes/Services"));
 const FastRengoering = React.lazy(() => import("./routes/services/FastRengoering"));


### PR DESCRIPTION
💡 What: Eagerly load the initial `Home` route in `src/App.tsx`.
🎯 Why: Lazy-loading the primary landing page introduces an unnecessary network roundtrip that delays the First Contentful Paint (FCP). Eagerly loading the root route ensures faster perceived performance on initial load.
📊 Impact: Improves FCP by removing the network waterfall for fetching the primary initial route chunk.
🔬 Measurement: Verify using Lighthouse performance metrics that the FCP score is improved compared to before the change.

---
*PR created automatically by Jules for task [15136613061512541134](https://jules.google.com/task/15136613061512541134) started by @JonasAbde*