### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limit bypass via IP spoofing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A missing type check for JSON payloads returned by `request.json()` caused 500 Internal Server errors when iterating over objects like `null` or `Array`, and a missing mechanism to clean up the `rateLimitHits` Map caused infinite memory growth resulting in a DoS vulnerability.
 **Learning:** Type validation is necessary for payloads parsed through `request.json()`, and in-memory Map rate limiters need a time-throttled cleanup mechanism.
 **Prevention:** Verify JSON payload types `if (!data || typeof data !== 'object' || Array.isArray(data))` before destructuring/object iteration. Use a time-throttled approach like `if (Date.now() - lastCleanupTime > interval)` to selectively clean up Map rate limiters without introducing high CPU utilization vulnerabilities.
+
+## 2024-05-24 - [Fix IP Spoofing Rate Limit Bypass]
+**Vulnerability:** The rate limiter in `functions/api/quote.ts` fell back to parsing the `X-Forwarded-For` header if `CF-Connecting-IP` was missing. `X-Forwarded-For` can be trivially spoofed by clients to bypass rate limits.
+**Learning:** In Cloudflare Pages Functions, security controls like rate limiters must rely exclusively on trustworthy headers populated directly by the network edge (e.g., `CF-Connecting-IP`).
+**Prevention:** Never use `X-Forwarded-For` or `crypto.randomUUID()` as fallbacks for missing IPs in security controls. Always fall back securely to a shared bucket like `'unknown'`.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -50,9 +50,8 @@ type HeaderReader = {
 };
 
 function getClientIp(headers: HeaderReader): string {
-  return headers.get('CF-Connecting-IP') ||
-    headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
-    'unknown';
+  // Use ONLY CF-Connecting-IP as X-Forwarded-For can be spoofed by clients to bypass rate limiting
+  return headers.get('CF-Connecting-IP') || 'unknown';
 }
 
 function isRateLimited(headers: HeaderReader): boolean {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The rate limiter in `functions/api/quote.ts` fell back to parsing the `X-Forwarded-For` header if `CF-Connecting-IP` was missing. `X-Forwarded-For` can be trivially spoofed by clients to bypass rate limits, potentially leading to API abuse or resource exhaustion.
🎯 **Impact:** An attacker could craft custom `X-Forwarded-For` headers to masquerade as different IPs on every request, completely bypassing the 3-request-per-minute limit on the `/api/quote` endpoint.
🔧 **Fix:** Modified `getClientIp` to strictly rely on the trusted `CF-Connecting-IP` header populated by Cloudflare's edge network, and securely fall back to a shared `'unknown'` bucket if missing.
✅ **Verification:** Verified that building the project (`pnpm build`) and linting (`pnpm lint`) succeed without any type errors or build failures. The solution is entirely contained in `< 50 lines`.

Included documentation of this vulnerability in the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [16440889238747542656](https://jules.google.com/task/16440889238747542656) started by @JonasAbde*