### PR TITLE
⚡ Bolt: Improve FCP by eagerly loading initial route

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+## 2024-05-24 - Improve FCP by eagerly loading the initial route
+**Learning:** Using `React.lazy()` for the initial/root route component (e.g., `Home` in `src/App.tsx`) creates a network waterfall on initial load. The browser must download and execute the main bundle before it even knows it needs to fetch the `Home` chunk, delaying the First Contentful Paint (FCP).
+**Action:** Always eagerly import the initial route component directly (e.g., `import Home from "./routes/Home";`) while continuing to lazy-load secondary routes.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import Layout from "./components/layout/Layout";
 import ScrollToTop from "./components/layout/ScrollToTop";
+import Home from "./routes/Home"; // Eagerly loaded for better FCP
 
-const Home = React.lazy(() => import("./routes/Home"));
 const About = React.lazy(() => import("./routes/About"));
 const Services = React.lazy(() => import("./routes/Services"));
 const FastRengoering = React.lazy(() => import("./routes/services/FastRengoering"));


### PR DESCRIPTION
💡 What: The initial route component (`Home`) is now eagerly imported rather than lazy-loaded in `src/App.tsx`.
🎯 Why: Using `React.lazy()` for the default route is an anti-pattern. It creates a network waterfall: the browser must download and execute the main JS bundle before it realizes it needs to fetch the `Home` chunk. This delays the First Contentful Paint (FCP).
📊 Impact: Measurably improves FCP by eliminating a secondary network roundtrip on initial page load. The main initial bundle size increases slightly, but the page becomes interactive significantly faster.
🔬 Measurement: Verified by running `pnpm build`. The `Home` component is no longer emitted as a separate chunk `Home-[hash].js` that is fetched subsequently, but rather included in the main `index-[hash].js` bundle.

---
*PR created automatically by Jules for task [11815901369905304300](https://jules.google.com/task/11815901369905304300) started by @JonasAbde*