### PR TITLE
⚡ Bolt: Eager load Home route for faster FCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+## 2025-03-08 - Eager Loading Initial Route
+**Learning:** Code-splitting the default/initial route (e.g., using `React.lazy` for `Home` in `App.tsx`) is a common anti-pattern that delays First Contentful Paint (FCP) because the browser must wait for React to initialize before fetching the required JS chunk.
+**Action:** Always eagerly load the initial landing page/root component and only apply lazy loading to secondary routes that the user navigates to later.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import Layout from "./components/layout/Layout";
 import ScrollToTop from "./components/layout/ScrollToTop";
+import Home from "./routes/Home"; // Eagerly load initial route for faster FCP
 
-const Home = React.lazy(() => import("./routes/Home"));
 const About = React.lazy(() => import("./routes/About"));
 const Services = React.lazy(() => import("./routes/Services"));
 const FastRengoering = React.lazy(() => import("./routes/services/FastRengoering"));


### PR DESCRIPTION
💡 What: Removed `React.lazy` wrapper from the `Home` route in `App.tsx` and used a static import instead.
🎯 Why: Code-splitting the default landing page delays the initial rendering (FCP) because the browser has to wait for React to bootstrap before fetching the chunk for the home page.
📊 Impact: Reduces First Contentful Paint (FCP) time and ensures the main application content loads with the initial bundle.
🔬 Measurement: Run a Lighthouse performance test before and after; the FCP metric should show improvement since the extra network request for the Home chunk is eliminated.

---
*PR created automatically by Jules for task [4656786930979795876](https://jules.google.com/task/4656786930979795876) started by @JonasAbde*