### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP Spoofing in Rate Limiter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A missing type check for JSON payloads returned by `request.json()` caused 500 Internal Server errors when iterating over objects like `null` or `Array`, and a missing mechanism to clean up the `rateLimitHits` Map caused infinite memory growth resulting in a DoS vulnerability.
 **Learning:** Type validation is necessary for payloads parsed through `request.json()`, and in-memory Map rate limiters need a time-throttled cleanup mechanism.
 **Prevention:** Verify JSON payload types `if (!data || typeof data !== 'object' || Array.isArray(data))` before destructuring/object iteration. Use a time-throttled approach like `if (Date.now() - lastCleanupTime > interval)` to selectively clean up Map rate limiters without introducing high CPU utilization vulnerabilities.
+
+## 2026-05-27 - [Fix IP Spoofing via X-Forwarded-For in Rate Limiter]
+**Vulnerability:** The application's rate limiter was falling back to the `X-Forwarded-For` header to determine the client's IP address when `CF-Connecting-IP` was missing (e.g., during local testing). This allowed malicious users to trivially bypass rate limits by spoofing their IP address via custom `X-Forwarded-For` headers.
+**Learning:** Cloudflare Pages Functions natively inject the trusted client IP into the `CF-Connecting-IP` header. User-supplied headers like `X-Forwarded-For` are unverified and must never be used for security controls or rate limiting.
+**Prevention:** Rely exclusively on `CF-Connecting-IP` for IP-based security controls in Cloudflare Workers/Pages Functions. If the header is absent (e.g., local development), default securely to a shared bucket like `'unknown'` rather than trusting potentially spoofed headers or using random UUIDs.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -50,9 +50,7 @@ type HeaderReader = {
 };
 
 function getClientIp(headers: HeaderReader): string {
-  return headers.get('CF-Connecting-IP') ||
-    headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
-    'unknown';
+  return headers.get('CF-Connecting-IP') || 'unknown';
 }
 
 function isRateLimited(headers: HeaderReader): boolean {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** IP Spoofing in Rate Limiter. The application previously fell back to using the `X-Forwarded-For` header if `CF-Connecting-IP` was missing. This permitted malicious actors to send custom `X-Forwarded-For` headers and easily spoof their IP address to bypass the rate limit, allowing them to spam the email quote API endpoint.
🎯 **Impact:** Rate limit bypass and potential abuse / resource exhaustion of the unauthenticated `/api/quote` endpoint (which sends emails via Resend).
🔧 **Fix:** Modified `getClientIp` in `functions/api/quote.ts` to strictly extract the IP from `CF-Connecting-IP`. If it is absent (such as in local development via Wrangler), we now fall back securely to `'unknown'`, effectively placing all such traffic into a single shared rate-limit bucket instead of trusting user input.
✅ **Verification:** Verified that tests, `pnpm lint`, and `pnpm build` pass with the new changes, and that there are no remaining occurrences of `X-Forwarded-For` in the file. Added a journal entry to `.jules/sentinel.md` documenting this learning.

---
*PR created automatically by Jules for task [9680983309843916710](https://jules.google.com/task/9680983309843916710) started by @JonasAbde*