### PR TITLE
⚡ Bolt: Eagerly import Home component for faster FCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+
+## 2024-05-24 - Eagerly Load Critical Initial Routes
+**Learning:** Using `React.lazy()` for the initial/root route component (e.g., `Home` in `src/App.tsx`) introduces an unnecessary network roundtrip that delays the First Contentful Paint (FCP).
+**Action:** Eagerly import critical initial routes (like `Home`) to ensure they are included in the main bundle and render immediately, while keeping less frequently accessed routes lazily loaded.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import Layout from "./components/layout/Layout";
 import ScrollToTop from "./components/layout/ScrollToTop";
+import Home from "./routes/Home"; // ⚡ Bolt: Eagerly imported to improve FCP
 
-const Home = React.lazy(() => import("./routes/Home"));
 const About = React.lazy(() => import("./routes/About"));
 const Services = React.lazy(() => import("./routes/Services"));
 const FastRengoering = React.lazy(() => import("./routes/services/FastRengoering"));


### PR DESCRIPTION
💡 **What**:
Changed `Home` component import in `src/App.tsx` from `React.lazy()` to an eager import.

🎯 **Why**:
Using `React.lazy()` for the initial/root route component introduces an unnecessary network roundtrip that delays the First Contentful Paint (FCP). The main page should always render as quickly as possible.

📊 **Impact**:
Improves First Contentful Paint (FCP) and reduces layout shift by ensuring the primary landing page content is included in the main bundle and renders immediately.

🔬 **Measurement**:
Can be verified by running Lighthouse performance audits or checking the Network tab in DevTools to confirm the `Home` chunk is no longer fetched as a separate, blocking request upon initial load.

---
*PR created automatically by Jules for task [5771289979452999180](https://jules.google.com/task/5771289979452999180) started by @JonasAbde*