### PR TITLE
🎨 Palette: Improve mobile menu accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-24 - [Mobile Menu Accessibility]
+**Learning:** Added `Escape` key listener, `aria-expanded` and `aria-controls` to the mobile menu toggle button, which improves keyboard accessibility and screen reader support without changing visual styling. This is a common pattern to apply for custom dropdowns and menus.
+**Action:** Always verify that interactive elements, especially custom toggles like a mobile hamburger menu, are fully accessible by keyboard (e.g., closing via Escape key) and have proper ARIA attributes to describe their state and control target.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -21,6 +21,16 @@ export default function Header() {
     if (path === "/" && location.pathname !== "/") return false;
     return location.pathname.startsWith(path) && path !== "/";
   };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobileMenuOpen]);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-slate-100 bg-white/80 backdrop-blur-md">
@@ -69,6 +79,8 @@ export default function Header() {
         <button
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -77,7 +89,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
💡 What: Improved keyboard accessibility and screen reader support for the mobile navigation menu.
🎯 Why: Users navigating with keyboards or screen readers need an intuitive way to understand the state of the mobile menu and to easily close it.
📸 Before/After: Visuals remain unchanged, but the interaction is now standard compliant.
♿ Accessibility:
- The `Escape` key closes the mobile menu, aligning with WAI-ARIA authoring practices.
- The `aria-expanded` property dynamically updates to inform screen readers of the menu's state.
- The `aria-controls` property explicitly links the toggle button to the menu container (`id="mobile-menu"`).

---
*PR created automatically by Jules for task [17107928771785000338](https://jules.google.com/task/17107928771785000338) started by @JonasAbde*