### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP Spoofing in Rate Limiter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A missing type check for JSON payloads returned by `request.json()` caused 500 Internal Server errors when iterating over objects like `null` or `Array`, and a missing mechanism to clean up the `rateLimitHits` Map caused infinite memory growth resulting in a DoS vulnerability.
 **Learning:** Type validation is necessary for payloads parsed through `request.json()`, and in-memory Map rate limiters need a time-throttled cleanup mechanism.
 **Prevention:** Verify JSON payload types `if (!data || typeof data !== 'object' || Array.isArray(data))` before destructuring/object iteration. Use a time-throttled approach like `if (Date.now() - lastCleanupTime > interval)` to selectively clean up Map rate limiters without introducing high CPU utilization vulnerabilities.
+
+## 2026-05-28 - [Fix IP Spoofing in Rate Limiter]
+**Vulnerability:** The application was using `X-Forwarded-For` header as a fallback to get the client IP for rate limiting. This allowed users to spoof their IP address by injecting a custom `X-Forwarded-For` header, bypassing the rate limiter.
+**Learning:** Cloudflare Pages Functions retrieve the client's actual IP address via the `CF-Connecting-IP` request header. `X-Forwarded-For` should never be trusted for security controls like rate limiting as it can be easily spoofed.
+**Prevention:** Rely exclusively on the `CF-Connecting-IP` header for security-related IP checks and fail securely to a shared bucket (like 'unknown') if the header is absent. Do not fall back to `X-Forwarded-For` or use UUIDs as fallbacks.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -50,9 +50,7 @@ type HeaderReader = {
 };
 
 function getClientIp(headers: HeaderReader): string {
-  return headers.get('CF-Connecting-IP') ||
-    headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
-    'unknown';
+  return headers.get('CF-Connecting-IP') || 'unknown';
 }
 
 function isRateLimited(headers: HeaderReader): boolean {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `X-Forwarded-For` header was used as a fallback to determine the client IP in the `/api/quote` rate limiter. This allows an attacker to inject a custom `X-Forwarded-For` header and easily spoof their IP address to completely bypass the rate limit.
🎯 Impact: Attackers could bypass the 3-requests-per-minute rate limit, allowing them to spam the endpoint, consume paid Resend API quotas, and exhaust server resources (DoS).
🔧 Fix: Removed the `X-Forwarded-For` fallback in the `getClientIp` function. Now, the application relies exclusively on Cloudflare's secure `CF-Connecting-IP` header and falls back securely to 'unknown'.
✅ Verification: The code was verified by running `pnpm lint` and `pnpm build`, ensuring no regressions in the API or build processes. Appended the vulnerability learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7016609618784023467](https://jules.google.com/task/7016609618784023467) started by @JonasAbde*