### PR TITLE
⚡ Bolt: Eagerly load Home component to improve FCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+## 2024-05-28 - Eagerly Load Critical Initial Routes
+**Learning:** Avoid using `React.lazy()` for the initial/root route component (e.g., `Home` in `src/App.tsx`), as it introduces an unnecessary network roundtrip that delays the First Contentful Paint (FCP).
+**Action:** Eagerly import critical initial routes instead of lazy loading them.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,9 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import Layout from "./components/layout/Layout";
 import ScrollToTop from "./components/layout/ScrollToTop";
+// Eagerly load the Home component to avoid an unnecessary network roundtrip and improve First Contentful Paint (FCP)
+import Home from "./routes/Home";
 
-const Home = React.lazy(() => import("./routes/Home"));
 const About = React.lazy(() => import("./routes/About"));
 const Services = React.lazy(() => import("./routes/Services"));
 const FastRengoering = React.lazy(() => import("./routes/services/FastRengoering"));


### PR DESCRIPTION
💡 What: Changed the import of the `Home` component in `src/App.tsx` from `React.lazy()` to an eager import.
🎯 Why: Lazy-loading the primary/index route of a Single Page Application (SPA) creates an unnecessary network waterfall, which negatively impacts the First Contentful Paint (FCP).
📊 Impact: Prevents an unnecessary network roundtrip, significantly improving FCP for the root route.
🔬 Measurement: Verify the improvement using Lighthouse or any performance monitoring tool to check the FCP score for the root route.

---
*PR created automatically by Jules for task [6459067638739263569](https://jules.google.com/task/6459067638739263569) started by @JonasAbde*