### PR TITLE
🎨 Palette: Improve mobile menu accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-18 - Improve Mobile Menu Accessibility
+**Learning:** Mobile menu toggle buttons should use `aria-expanded` reflecting the menu state and `aria-controls` pointing to the menu container's ID to improve screen reader accessibility. Additionally, capturing the `Escape` key to close the mobile menu significantly improves keyboard accessibility.
+**Action:** Ensure that all toggleable menus, dialogs, and popovers explicitly define `aria-expanded` on the trigger, `aria-controls` linking the trigger to the content, and implement an `Escape` key listener to dismiss the content, following existing design patterns.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -7,6 +7,17 @@ import { cn } from "@/lib/utils";
 export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobileMenuOpen]);
 
   const navLinks = [
     { name: "Forside", path: "/" },
@@ -70,6 +81,8 @@ export default function Header() {
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -77,7 +90,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
💡 **What:** Added `aria-expanded` and `aria-controls` attributes to the mobile menu toggle button. Assigned an `id` to the mobile navigation container to map it to the `aria-controls`. Also added a document-level `Escape` key listener to dismiss the open mobile menu.

🎯 **Why:** Custom popovers and mobile menus are opaque to screen readers if they lack explicit ARIA states indicating when they are expanded and what content they control. Furthermore, keyboard users depend on the `Escape` key to quickly dismiss open dialogs and menus without tabbing through all contents to find the close button.

♿ **Accessibility:**
- Added `aria-expanded` tracking `isMobileMenuOpen` state.
- Added `aria-controls="mobile-menu"` linking to the menu container.
- Added `Escape` key listener to close the mobile menu.

---
*PR created automatically by Jules for task [7373173036479971504](https://jules.google.com/task/7373173036479971504) started by @JonasAbde*