### PR TITLE
🎨 Palette: Add keyboard focus states and ARIA controls to cookie banner

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+
+## 2024-05-30 - Expandable Sections and ARIA Controls
+**Learning:** When using expandable sections like settings or details panels, screen reader users need to be informed about the state and relationship of the toggle button and the expandable content. Without explicit ARIA attributes, the association and state are visually implied but programmatically hidden.
+**Action:** Always add `aria-expanded` reflecting the state (e.g., `aria-expanded={isOpen}`) and `aria-controls` pointing to the `id` of the expandable container to toggle buttons that control collapsible sections.

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -94,7 +94,7 @@ export default function CookieConsent() {
     return (
       <button
         onClick={handleWithdrawConsent}
-        className="fixed bottom-20 left-4 z-40 p-2 bg-white rounded-full shadow-lg hover:shadow-xl transition-shadow md:bottom-4"
+        className="fixed bottom-20 left-4 z-40 p-2 bg-white rounded-full shadow-lg hover:shadow-xl transition-shadow md:bottom-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500"
         title="Administrer cookies"
         aria-label="Administrer cookies"
       >
@@ -125,7 +125,7 @@ export default function CookieConsent() {
                 </p>
                 <a 
                   href="/cookiepolitik" 
-                  className="text-green-600 text-sm hover:underline inline-flex items-center gap-1"
+                  className="text-green-600 text-sm hover:underline inline-flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500 rounded-sm"
                 >
                   Læs vores cookiepolitik
                 </a>
@@ -141,7 +141,7 @@ export default function CookieConsent() {
                     timestamp: new Date().toISOString(),
                   });
                 }}
-                className="p-1 hover:bg-slate-100 rounded-full transition-colors"
+                className="p-1 hover:bg-slate-100 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500"
                 aria-label="Luk cookie banner"
               >
                 <X className="w-5 h-5 text-slate-400" />
@@ -171,6 +171,7 @@ export default function CookieConsent() {
 
               {showDetails && (
                 <motion.div
+                  id="cookie-details"
                   initial={{ opacity: 0, height: 0 }}
                   animate={{ opacity: 1, height: 'auto' }}
                   className="space-y-3"
@@ -221,19 +222,21 @@ export default function CookieConsent() {
             <div className="mt-4 flex flex-wrap items-center gap-3">
               <button
                 onClick={handleAcceptAll}
-                className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 transition-colors"
+                className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500"
               >
                 Accepter alle
               </button>
               <button
                 onClick={handleRejectAll}
-                className="px-4 py-2 bg-white text-slate-700 border border-slate-300 rounded-lg font-medium hover:bg-slate-50 transition-colors"
+                className="px-4 py-2 bg-white text-slate-700 border border-slate-300 rounded-lg font-medium hover:bg-slate-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500"
               >
                 Afvis alle
               </button>
               <button
                 onClick={() => setShowDetails(!showDetails)}
-                className="px-4 py-2 text-slate-600 hover:text-slate-900 transition-colors inline-flex items-center gap-2"
+                className="px-4 py-2 text-slate-600 hover:text-slate-900 transition-colors inline-flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500 rounded-lg"
+                aria-expanded={showDetails}
+                aria-controls="cookie-details"
               >
                 <Settings className="w-4 h-4" />
                 {showDetails ? 'Skjul indstillinger' : 'Indstillinger'}
@@ -241,7 +244,7 @@ export default function CookieConsent() {
               {showDetails && (
                 <button
                   onClick={handleAcceptSelected}
-                  className="px-4 py-2 bg-slate-800 text-white rounded-lg font-medium hover:bg-slate-900 transition-colors"
+                  className="px-4 py-2 bg-slate-800 text-white rounded-lg font-medium hover:bg-slate-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500"
                 >
                   Gem valg
                 </button>


### PR DESCRIPTION
💡 **What**: Added explicit `focus-visible` Tailwind classes to all buttons and links within the `CookieConsent` banner. Additionally, explicitly linked the "Settings" toggle button to the expandable details section using `aria-expanded` and `aria-controls` with a matching `id`.

🎯 **Why**: Mouse users click buttons and banners disappear or expand, but keyboard users depend on focus rings to see where their cursor currently rests. Using `focus-visible` gives keyboard users high visibility without showing ugly rings to mouse clickers. Furthermore, screen reader users need to be programmatically informed when a button toggles an expandable section and whether it is currently expanded or collapsed.

📸 **Before/After**: 
- **Before**: Tabbing through the cookie banner provided no clear visual indication of which button or link had focus. The settings button toggle state was visually implied but programmatically hidden.
- **After**: Tabbing now outlines the active button or link with a clear green ring (`focus-visible:ring-2 focus-visible:ring-green-500`). The settings toggle button now properly alerts screen readers to its expanded/collapsed state and what container it controls.

♿ **Accessibility**: 
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500` to all interactive elements.
- Added `aria-expanded={showDetails}` to the settings button.
- Added `aria-controls="cookie-details"` to the settings button.
- Added `id="cookie-details"` to the expandable `<motion.div>`.

---
*PR created automatically by Jules for task [14297624817444509522](https://jules.google.com/task/14297624817444509522) started by @JonasAbde*