### PR TITLE
⚡ Bolt: Eagerly load Home route for faster FCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+
+## 2024-05-30 - Prevent Network Waterfall on Initial Load
+**Learning:** In a single-page application heavily utilizing `React.lazy()` for route-based code splitting, lazy loading the *initial root route* (e.g., `Home.tsx` in `App.tsx`) causes a critical performance bottleneck. It forces the browser into a network waterfall: fetch the main JS bundle -> parse -> discover it needs the Home chunk -> fetch the Home chunk -> render. This significantly delays the First Contentful Paint (FCP).
+**Action:** Always eagerly import the initial root route (`Home`) using a standard import, while keeping secondary routes lazy loaded. This ensures the initial UI renders instantly alongside the main bundle while preserving the code-splitting benefits for the rest of the application.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import Layout from "./components/layout/Layout";
 import ScrollToTop from "./components/layout/ScrollToTop";
+import Home from "./routes/Home"; // ⚡ Bolt: Eagerly load initial route to improve FCP
 
-const Home = React.lazy(() => import("./routes/Home"));
 const About = React.lazy(() => import("./routes/About"));
 const Services = React.lazy(() => import("./routes/Services"));
 const FastRengoering = React.lazy(() => import("./routes/services/FastRengoering"));


### PR DESCRIPTION
**💡 What:** Replaced the `React.lazy()` import with a standard static import for the `Home` route in `src/App.tsx`.
**🎯 Why:** Lazy-loading the initial/root route causes a network waterfall: the browser must fetch and parse the main JS bundle before it even discovers that it needs to fetch the chunk containing the Home component. This significantly delays the initial render of the page.
**📊 Impact:** Measurably improves the First Contentful Paint (FCP) and Largest Contentful Paint (LCP) by eliminating an unnecessary roundtrip request during the initial page load for the majority of visitors, while preserving the code-splitting benefits for all secondary routes.
**🔬 Measurement:** Verified by running `pnpm build` which confirms the `Home` route is now bundled directly into the main entry chunk (`dist/assets/index-*.js`) instead of a separate chunk.

---
*PR created automatically by Jules for task [7162009848148031514](https://jules.google.com/task/7162009848148031514) started by @JonasAbde*