### PR TITLE
🛡️ Sentinel: [HIGH] Fix IP spoofing vulnerability in rate limiting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,7 @@
 **Vulnerability:** A missing type check for JSON payloads returned by `request.json()` caused 500 Internal Server errors when iterating over objects like `null` or `Array`, and a missing mechanism to clean up the `rateLimitHits` Map caused infinite memory growth resulting in a DoS vulnerability.
 **Learning:** Type validation is necessary for payloads parsed through `request.json()`, and in-memory Map rate limiters need a time-throttled cleanup mechanism.
 **Prevention:** Verify JSON payload types `if (!data || typeof data !== 'object' || Array.isArray(data))` before destructuring/object iteration. Use a time-throttled approach like `if (Date.now() - lastCleanupTime > interval)` to selectively clean up Map rate limiters without introducing high CPU utilization vulnerabilities.
+## 2024-05-31 - [High] IP Spoofing via X-Forwarded-For
+**Vulnerability:** Rate limiting relied on `X-Forwarded-For` as a fallback when `CF-Connecting-IP` was missing. This allows attackers to bypass rate limits by spoofing the `X-Forwarded-For` header.
+**Learning:** Cloudflare Pages Functions retrieve the client's IP address via the `CF-Connecting-IP` request header. For security controls like rate limiting, rely exclusively on this header and do not fall back to `X-Forwarded-For` to prevent IP spoofing attacks.
+**Prevention:** Always use `CF-Connecting-IP` for IP-based security controls in Cloudflare environments. Fail securely to a shared bucket like 'unknown' if it's missing.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -50,9 +50,7 @@ type HeaderReader = {
 };
 
 function getClientIp(headers: HeaderReader): string {
-  return headers.get('CF-Connecting-IP') ||
-    headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
-    'unknown';
+  return headers.get('CF-Connecting-IP') || 'unknown';
 }
 
 function isRateLimited(headers: HeaderReader): boolean {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The rate-limiting logic in `functions/api/quote.ts` used `X-Forwarded-For` as a fallback when identifying the client IP. This allows an attacker to spoof the `X-Forwarded-For` header and bypass rate limiting.
🎯 **Impact**: Attackers could bypass rate limiting, leading to resource exhaustion or abuse of the external API (Resend).
🔧 **Fix**: Modified `getClientIp` to rely exclusively on `CF-Connecting-IP`, falling back securely to `'unknown'`.
✅ **Verification**: Verified using `pnpm lint` and `pnpm build`. Added a learning entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4198728509941072485](https://jules.google.com/task/4198728509941072485) started by @JonasAbde*