### PR TITLE
🎨 Palette: Improve mobile menu accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+## 2024-05-31 - Mobile Menu Accessibility
+**Learning:** Mobile navigation toggles need explicit ARIA states (`aria-expanded`, `aria-controls`) and an `Escape` key listener to ensure full screen reader support and keyboard navigability, aligning with WCAG standards for expandable sections.
+**Action:** Always implement `useEffect` listeners for the `Escape` key and explicitly link toggle buttons to their collapsible regions using `aria-controls` and dynamic `aria-expanded` attributes.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -7,6 +7,17 @@ import { cn } from "@/lib/utils";
 export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   const navLinks = [
     { name: "Forside", path: "/" },
@@ -70,6 +81,8 @@ export default function Header() {
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -77,7 +90,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
💡 **What**: Added an `Escape` keydown listener to the mobile menu and included `aria-expanded`, `aria-controls`, and an ID linkage to the toggle button and container.
🎯 **Why**: To align the mobile menu toggle with WCAG guidelines for expandable/collapsible sections, significantly improving keyboard navigability and making the state clear to screen reader users.
♿ **Accessibility**: Resolves an issue where screen reader users couldn't identify the connection between the button and the menu or determine whether it was open. Allows keyboard-only users to easily close the menu without having to tab back to the close button.

---
*PR created automatically by Jules for task [17944609878093791114](https://jules.google.com/task/17944609878093791114) started by @JonasAbde*