### PR TITLE
⚡ Bolt: Eagerly import initial Home route to improve FCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+## 2024-05-24 - Eagerly import initial route to reduce network roundtrip
+**Learning:** Using `React.lazy()` for the initial/root route component (e.g., `Home` in `src/App.tsx`) introduces an unnecessary network roundtrip that delays the First Contentful Paint (FCP) because the browser has to first download the main bundle, render the component tree, and then fetch the home route chunk.
+**Action:** Eagerly import the critical initial route components instead of lazy-loading them.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,10 @@ import { HelmetProvider } from "react-helmet-async";
 import Layout from "./components/layout/Layout";
 import ScrollToTop from "./components/layout/ScrollToTop";
 
-const Home = React.lazy(() => import("./routes/Home"));
+// Eagerly import the initial route component to avoid an unnecessary network roundtrip
+// that delays First Contentful Paint (FCP).
+import Home from "./routes/Home";
+
 const About = React.lazy(() => import("./routes/About"));
 const Services = React.lazy(() => import("./routes/Services"));
 const FastRengoering = React.lazy(() => import("./routes/services/FastRengoering"));


### PR DESCRIPTION
💡 **What:** Eagerly imports the `Home` route component in `src/App.tsx` instead of using `React.lazy()`.
🎯 **Why:** Lazy loading the initial route introduces a network waterfall (download main bundle -> parse/render -> trigger lazy load -> download chunk -> render) which unnecessarily delays the First Contentful Paint (FCP) and Largest Contentful Paint (LCP) for users landing on the main page.
📊 **Impact:** Reduces initial page load time by eliminating one entire network roundtrip.
🔬 **Measurement:** Verify via network tab in DevTools (fewer blocking JS requests before rendering the initial view) and Lighthouse performance metrics.

---
*PR created automatically by Jules for task [4152493488052363527](https://jules.google.com/task/4152493488052363527) started by @JonasAbde*