### PR TITLE
🎨 Palette: Improve Mobile Menu Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+## 2024-06-01 - Improve Expandable Container Accessibility
+**Learning:** Toggle buttons controlling expandable sections (e.g., mobile menus, settings panels) require explicit state and association for screen reader compatibility. Users must be able to escape the context intuitively via the keyboard.
+**Action:** Always add `aria-expanded` (boolean) reflecting their state, and `aria-controls` pointing to the expandable container's ID. Implement an `Escape` key listener for proper keyboard support.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Phone } from "lucide-react";
 import { company } from "@/content/company";
@@ -7,6 +7,17 @@ import { cn } from "@/lib/utils";
 export default function Header() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const location = useLocation();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isMobileMenuOpen) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobileMenuOpen]);
 
   const navLinks = [
     { name: "Forside", path: "/" },
@@ -69,6 +80,8 @@ export default function Header() {
         <button
           className="md:hidden p-2 text-slate-600 hover:text-slate-900 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-menu"
           aria-label={isMobileMenuOpen ? "Luk menu" : "Åbn menu"}
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -77,7 +90,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
-        <div className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
+        <div id="mobile-menu" className="md:hidden border-t border-slate-100 bg-white px-4 py-6 shadow-lg">
           <nav className="flex flex-col space-y-4">
             {navLinks.map((link) => (
               <Link


### PR DESCRIPTION
**💡 What:** 
Added `aria-expanded` and `aria-controls` attributes to the mobile menu toggle button, added an `id="mobile-menu"` to the mobile menu container, and implemented an `Escape` key listener to close the mobile menu.

**🎯 Why:** 
These changes significantly improve the accessibility of the mobile menu. Screen readers can now properly understand the state and association of the toggle button and its expandable container. Additionally, keyboard users can now intuitively close the mobile menu by pressing the `Escape` key.

**📸 Before/After:** 
No visual changes.

**♿ Accessibility:** 
- Added `aria-expanded` to reflect the open/closed state of the mobile menu.
- Added `aria-controls` to explicitly link the toggle button with the menu container.
- Added an `Escape` key listener for proper keyboard navigation and intuitive interaction.

---
*PR created automatically by Jules for task [3031419751871335249](https://jules.google.com/task/3031419751871335249) started by @JonasAbde*