### PR TITLE
🎨 Palette: Form accessibility and screen reader support

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-05-01 - Accessible Navigation and Danish Localization
 **Learning:** Using `focus-visible` classes ensures that keyboard users still receive focus rings while mouse users do not, which improves the UX by preventing unwanted rings on click. Additionally, accessibility attributes like `aria-label` must be localized properly (e.g., from 'Toggle menu' to 'Åbn menu'/'Luk menu' in Danish) to ensure screen readers communicate properly in the application's locale.
 **Action:** Use `focus-visible` classes instead of generic `focus` classes for all newly added interactive elements, and verify that ARIA strings match the application's native language context.
+## 2024-06-02 - Form Accessibility and Screen Reader Support
+**Learning:** Inputs that rely exclusively on placeholders for visible labels must include an `aria-label` to be accessible. Custom input groups acting as radio buttons (like button-based selection arrays) must explicitly apply ARIA grouping (`role="radiogroup"` and `aria-labelledby`) and element states (`role="radio"`, `aria-checked`) to communicate properly with screen readers.
+**Action:** Always verify that placeholder-only inputs have `aria-label`s, and ensure custom selection groups use the correct `radiogroup` and `radio` roles with corresponding state attributes.

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -77,15 +77,17 @@ function QuickQuoteForm() {
 
       {/* Service type selector */}
       <div>
-        <p className="text-sm font-medium text-slate-700 mb-3">Hvilken type rengøring?</p>
-        <div className="flex flex-wrap gap-2">
+        <p id="quick-quote-service-type" className="text-sm font-medium text-slate-700 mb-3">Hvilken type rengøring?</p>
+        <div role="radiogroup" aria-labelledby="quick-quote-service-type" className="flex flex-wrap gap-2">
           {serviceTypes.map((s) => (
             <button
               key={s.id}
               type="button"
+              role="radio"
+              aria-checked={serviceType === s.id}
               onClick={() => setServiceType(s.id)}
               disabled={formState === "submitting"}
-              className={`px-4 py-2 rounded-full text-sm font-medium border transition-colors ${
+              className={`px-4 py-2 rounded-full text-sm font-medium border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2 ${
                 serviceType === s.id
                   ? "bg-green-600 text-white border-green-600"
                   : "bg-white text-slate-700 border-slate-300 hover:border-green-400"
@@ -99,6 +101,7 @@ function QuickQuoteForm() {
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <input
           type="text"
+          aria-label="Navn"
           placeholder="Navn"
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -108,6 +111,7 @@ function QuickQuoteForm() {
         />
         <input
           type="tel"
+          aria-label="Telefon"
           placeholder="Telefon"
           value={phone}
           onChange={(e) => setPhone(e.target.value)}
@@ -117,6 +121,7 @@ function QuickQuoteForm() {
         />
         <input
           type="email"
+          aria-label="Email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
@@ -126,6 +131,7 @@ function QuickQuoteForm() {
         />
       </div>
       <textarea
+        aria-label="Fortæl kort om opgaven (valgfri)"
         placeholder="Fortæl kort om opgaven (valgfri)"
         value={message}
         onChange={(e) => setMessage(e.target.value)}


### PR DESCRIPTION
💡 What: Added missing `aria-label`s to form inputs that use placeholders instead of visible labels, and converted a custom button selection group into an explicitly grouped ARIA radiogroup.
🎯 Why: Screen readers cannot always reliably interpret placeholder text as form labels. Custom input groups acting like radio buttons need explicit ARIA roles to communicate selection states and grouping to assistive technologies. Keyboard users also need clear focus indicators when navigating the custom button array.
📸 Before/After: Visual changes are limited to a clean focus ring when navigating the service selector via keyboard.
♿ Accessibility:
- Keyboard navigation: Improved focus visibility on service selection buttons.
- Screen readers: Form inputs now explicitly labeled via `aria-label`. Service selector now behaves as a semantic radiogroup with proper state communication (`aria-checked`).

---
*PR created automatically by Jules for task [7349738115949893289](https://jules.google.com/task/7349738115949893289) started by @JonasAbde*