### PR TITLE
⚡ Bolt: Eager load initial route to improve FCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Prevent Redundant Computations with useMemo
 **Learning:** In React components like `PriceCalculator`, using `useEffect` to derive state from props and update local state (e.g. `estimate`) causes an immediate secondary re-render.
 **Action:** Replace `useEffect` that only sets state with `useMemo` to compute derived data synchronously during render, saving unnecessary render cycles.
+
+## 2024-05-24 - Eager Load Initial Route to Improve FCP
+**Learning:** Avoiding `React.lazy` for the initial/root route component (e.g., `Home` in `src/App.tsx`) as it introduces an unnecessary network roundtrip that delays the First Contentful Paint (FCP).
+**Action:** Eagerly import critical initial routes instead of lazy loading them, and use named exports like `import { lazy } from 'react'` instead of `React.lazy` for cleaner code in React 19/Vite environments.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,26 @@
-import React, { Suspense } from "react";
+import { lazy, Suspense } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import Layout from "./components/layout/Layout";
 import ScrollToTop from "./components/layout/ScrollToTop";
 
-const Home = React.lazy(() => import("./routes/Home"));
-const About = React.lazy(() => import("./routes/About"));
-const Services = React.lazy(() => import("./routes/Services"));
-const FastRengoering = React.lazy(() => import("./routes/services/FastRengoering"));
-const Flytterengoering = React.lazy(() => import("./routes/services/Flytterengoering"));
-const Hovedrengoering = React.lazy(() => import("./routes/services/Hovedrengoering"));
-const Erhvervsrengoering = React.lazy(() => import("./routes/services/Erhvervsrengoering"));
-const Pricing = React.lazy(() => import("./routes/Pricing"));
-const ServiceAreas = React.lazy(() => import("./routes/ServiceAreas"));
-const FlyttesynGuide = React.lazy(() => import("./routes/FlyttesynGuide"));
-const RengoeringPriser = React.lazy(() => import("./routes/guides/RengoeringPriser"));
-const FAQ = React.lazy(() => import("./routes/FAQ"));
-const Contact = React.lazy(() => import("./routes/Contact"));
-const Terms = React.lazy(() => import("./routes/Terms"));
-const Privacy = React.lazy(() => import("./routes/Privacy"));
-const Cookies = React.lazy(() => import("./routes/Cookies"));
-const NotFound = React.lazy(() => import("./routes/NotFound"));
+import Home from "./routes/Home"; // Eagerly import critical initial route to eliminate network roundtrip and improve First Contentful Paint (FCP)
+const About = lazy(() => import("./routes/About"));
+const Services = lazy(() => import("./routes/Services"));
+const FastRengoering = lazy(() => import("./routes/services/FastRengoering"));
+const Flytterengoering = lazy(() => import("./routes/services/Flytterengoering"));
+const Hovedrengoering = lazy(() => import("./routes/services/Hovedrengoering"));
+const Erhvervsrengoering = lazy(() => import("./routes/services/Erhvervsrengoering"));
+const Pricing = lazy(() => import("./routes/Pricing"));
+const ServiceAreas = lazy(() => import("./routes/ServiceAreas"));
+const FlyttesynGuide = lazy(() => import("./routes/FlyttesynGuide"));
+const RengoeringPriser = lazy(() => import("./routes/guides/RengoeringPriser"));
+const FAQ = lazy(() => import("./routes/FAQ"));
+const Contact = lazy(() => import("./routes/Contact"));
+const Terms = lazy(() => import("./routes/Terms"));
+const Privacy = lazy(() => import("./routes/Privacy"));
+const Cookies = lazy(() => import("./routes/Cookies"));
+const NotFound = lazy(() => import("./routes/NotFound"));
 
 const Loading = () => (
   <div className="flex items-center justify-center min-h-screen">


### PR DESCRIPTION
💡 **What:** Eagerly load the initial `Home` component in `src/App.tsx` instead of using `React.lazy`. Also refactored existing `React.lazy` imports to use the named `lazy` import.
🎯 **Why:** Lazy loading the initial route forces an unnecessary network roundtrip before the main content can render, delaying the First Contentful Paint (FCP).
📊 **Impact:** Reduces FCP time by eliminating one script fetch block. This is a crucial metric for perceived load performance.
🔬 **Measurement:** Verify by measuring the First Contentful Paint (FCP) metric in Lighthouse before and after the change.

---
*PR created automatically by Jules for task [10300490651812359451](https://jules.google.com/task/10300490651812359451) started by @JonasAbde*