### PR TITLE
🛡️ Sentinel: [HIGH] Fix rate limit bypass via IP spoofing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A missing type check for JSON payloads returned by `request.json()` caused 500 Internal Server errors when iterating over objects like `null` or `Array`, and a missing mechanism to clean up the `rateLimitHits` Map caused infinite memory growth resulting in a DoS vulnerability.
 **Learning:** Type validation is necessary for payloads parsed through `request.json()`, and in-memory Map rate limiters need a time-throttled cleanup mechanism.
 **Prevention:** Verify JSON payload types `if (!data || typeof data !== 'object' || Array.isArray(data))` before destructuring/object iteration. Use a time-throttled approach like `if (Date.now() - lastCleanupTime > interval)` to selectively clean up Map rate limiters without introducing high CPU utilization vulnerabilities.
+
+## 2026-06-02 - [Fix Rate Limit Bypass via IP Spoofing]
+**Vulnerability:** The application was using the `X-Forwarded-For` header as a fallback to identify client IPs for rate limiting if `CF-Connecting-IP` was not present. Since `X-Forwarded-For` can be easily manipulated by users, attackers could spoof their IP addresses to bypass rate limiting controls.
+**Learning:** Cloudflare Pages provide the `CF-Connecting-IP` header representing the true client IP. Relying on headers like `X-Forwarded-For` in a reverse proxy environment opens the door to IP spoofing and bypass of IP-based security controls.
+**Prevention:** For rate limiting or security mechanisms, rely exclusively on trusted headers provided by your infrastructure (like `CF-Connecting-IP`). Never fall back to user-controllable headers to determine a client's IP, failing securely to a shared bucket (like `'unknown'`) if the header is absent.

--- a/functions/api/quote.ts
+++ b/functions/api/quote.ts
@@ -50,9 +50,7 @@ type HeaderReader = {
 };
 
 function getClientIp(headers: HeaderReader): string {
-  return headers.get('CF-Connecting-IP') ||
-    headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
-    'unknown';
+  return headers.get('CF-Connecting-IP') || 'unknown';
 }
 
 function isRateLimited(headers: HeaderReader): boolean {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was using the `X-Forwarded-For` header as a fallback to identify client IPs for rate limiting if `CF-Connecting-IP` was not present. Because the first value in `X-Forwarded-For` is user-controllable, attackers could easily spoof their IP address to bypass rate limiting controls.
🎯 **Impact:** Attackers could bypass rate limits, potentially leading to abuse of the Resend email API or resource exhaustion via a Denial of Service attack.
🔧 **Fix:** Removed the user-controllable fallback. `getClientIp` now relies exclusively on the trusted `CF-Connecting-IP` header provided by Cloudflare Pages, securely falling back to the `'unknown'` bucket if missing.
✅ **Verification:** Ran `pnpm lint` and `pnpm build` to verify no regressions in the codebase. Code review approved the fix. Documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15544371619937996988](https://jules.google.com/task/15544371619937996988) started by @JonasAbde*